### PR TITLE
Refactor the stats computation and filtering logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ MAGMA (**M**aximum **A**ccessible **G**enome for **M**tb **A**nalysis) is a pipe
   - Execution (software) requirements (`conf/docker.config` or `conf/conda.config`)
 - An (optional) GVCF reference dataset for ~600 samples is provided for augmenting smaller datasets
 
-> **Note**
-Downloading the reference EXIT_RIF GVCF files from FIXME
+
+# (Optional) GVCF for analyzing small number of samples
+
+You can download the  `EXIT_RIF GVCF` files from https://zenodo.org/record/8054182
 
 ## Tutorials and Presentations
 

--- a/bin/generate_merged_cohort_stats.py
+++ b/bin/generate_merged_cohort_stats.py
@@ -14,8 +14,12 @@ if __name__ == '__main__':
     
     # Read all CSV files
     df_cohort_stats = pd.read_csv(args['call_wf_cohort_stats_tsv'], sep="\t", index_col="SAMPLE")
+
     df_approved_relabundance_stats =  pd.read_csv(args['relabundance_approved_tsv'], sep="\t", index_col="SAMPLE")
+    df_approved_relabundance_stats =  df_approved_relabundance_stats.convert_dtypes()
+
     df_rejected_relabundance_stats =  pd.read_csv(args['relabundance_rejected_tsv'], sep="\t", index_col="SAMPLE")
+    df_rejected_relabundance_stats =  df_rejected_relabundance_stats.convert_dtypes()
     
     # Join the datasets
     df_relabundance_stats_concat = pd.concat([df_approved_relabundance_stats, df_rejected_relabundance_stats])

--- a/bin/generate_merged_cohort_stats.py
+++ b/bin/generate_merged_cohort_stats.py
@@ -5,9 +5,9 @@ import pandas as pd
 
     
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Summarize the CALL_WF and MINOR_VARIANT_ANALYSIS_WF analysis results')
-    parser.add_argument('--relabundance_approved_tsv', default="approved_samples.relabundance.tsv", metavar='relabundance_approved_tsv', type=str, help='File enlisting the approved samples from MINOR_VARIANT_ANALYSIS_WF')
-    parser.add_argument('--relabundance_rejected_tsv', default="rejected_samples.relabundance.tsv", metavar='relabundance_rejected_tsv', type=str, help='File enlisting the rejected samples from MINOR_VARIANT_ANALYSIS_WF')
+    parser = argparse.ArgumentParser(description='Summarize the CALL_WF and MINOR_VARIANTS_ANALYSIS_WF analysis results')
+    parser.add_argument('--relabundance_approved_tsv', default="approved_samples.relabundance.tsv", metavar='relabundance_approved_tsv', type=str, help='File enlisting the approved samples from MINOR_VARIANTS_ANALYSIS_WF')
+    parser.add_argument('--relabundance_rejected_tsv', default="rejected_samples.relabundance.tsv", metavar='relabundance_rejected_tsv', type=str, help='File enlisting the rejected samples from MINOR_VARIANTS_ANALYSIS_WF')
     parser.add_argument('--call_wf_cohort_stats_tsv', default="joint.cohort_stats.tsv", metavar='call_wf_cohort_stats_tsv', type=str, help='File enlisting the cohort results of CALL_WF')
     parser.add_argument('--output_file', default="joint.merged_cohort_stats.tsv", metavar='output_file', type=str, help='Name of the output file merged cohort statistics')
     args = vars(parser.parse_args())

--- a/bin/generate_merged_cohort_stats.py
+++ b/bin/generate_merged_cohort_stats.py
@@ -11,21 +11,49 @@ if __name__ == '__main__':
     parser.add_argument('--call_wf_cohort_stats_tsv', default="joint.cohort_stats.tsv", metavar='call_wf_cohort_stats_tsv', type=str, help='File enlisting the cohort results of CALL_WF')
     parser.add_argument('--output_file', default="joint.merged_cohort_stats.tsv", metavar='output_file', type=str, help='Name of the output file merged cohort statistics')
     args = vars(parser.parse_args())
-    
-    # Read all CSV files
-    df_cohort_stats = pd.read_csv(args['call_wf_cohort_stats_tsv'], sep="\t", index_col="SAMPLE")
 
-    df_approved_relabundance_stats =  pd.read_csv(args['relabundance_approved_tsv'], sep="\t", index_col="SAMPLE")
-    df_approved_relabundance_stats =  df_approved_relabundance_stats.convert_dtypes()
+    # Read the TSV files into dataframes
+    df_cohort_stats = pd.read_csv(args['call_wf_cohort_stats_tsv'], sep="\t")
+    df_cohort_stats.columns = df_cohort_stats.columns.str.strip()
+    df_cohort_stats['SAMPLE'] = df_cohort_stats['SAMPLE'].str.strip()
+    df_cohort_stats = df_cohort_stats.set_index('SAMPLE')
 
-    df_rejected_relabundance_stats =  pd.read_csv(args['relabundance_rejected_tsv'], sep="\t", index_col="SAMPLE")
-    df_rejected_relabundance_stats =  df_rejected_relabundance_stats.convert_dtypes()
-    
+
+    df_approved_relabundance_stats =  pd.read_csv(args['relabundance_approved_tsv'], sep="\t")
+    df_approved_relabundance_stats.columns =  df_approved_relabundance_stats.columns.str.strip()
+    df_approved_relabundance_stats['SAMPLE'] = df_approved_relabundance_stats['SAMPLE'].str.strip()
+    df_approved_relabundance_stats = df_approved_relabundance_stats.set_index('SAMPLE')
+
+
+    df_rejected_relabundance_stats =  pd.read_csv(args['relabundance_rejected_tsv'], sep="\t")
+    df_rejected_relabundance_stats.columns =  df_rejected_relabundance_stats.columns.str.strip()
+    df_rejected_relabundance_stats['SAMPLE'] = df_rejected_relabundance_stats['SAMPLE'].str.strip()
+    df_rejected_relabundance_stats = df_rejected_relabundance_stats.set_index('SAMPLE')
+
+
     # Join the datasets
     df_relabundance_stats_concat = pd.concat([df_approved_relabundance_stats, df_rejected_relabundance_stats])
-    df_joint_cohort_stats =  df_cohort_stats.join(df_relabundance_stats_concat, on="SAMPLE", how="left")
-  
+    df_joint_cohort_stats =  df_cohort_stats.join(df_relabundance_stats_concat, how="outer")
+
+
     # Reorder the columns
+    df_joint_cohort_stats.columns = df_joint_cohort_stats.columns.str.strip()
     new_cols = ['AVG_INSERT_SIZE', 'MAPPED_PERCENTAGE', 'RAW_TOTAL_SEQS', 'AVERAGE_BASE_QUALITY', 'MEAN_COVERAGE', 'SD_COVERAGE', 'MEDIAN_COVERAGE', 'MAD_COVERAGE', 'PCT_EXC_ADAPTER', 'PCT_EXC_MAPQ', 'PCT_EXC_DUPE', 'PCT_EXC_UNPAIRED', 'PCT_EXC_BASEQ', 'PCT_EXC_OVERLAP', 'PCT_EXC_CAPPED', 'PCT_EXC_TOTAL', 'PCT_1X', 'PCT_5X', 'PCT_10X', 'PCT_30X', 'PCT_50X', 'PCT_100X', 'LINEAGES', 'FREQUENCIES', 'MAPPED_NTM_FRACTION_16S', 'MAPPED_NTM_FRACTION_16S_THRESHOLD_MET', 'COVERAGE_THRESHOLD_MET', 'BREADTH_OF_COVERAGE_THRESHOLD_MET', 'RELABUNDANCE_THRESHOLD_MET', 'ALL_THRESHOLDS_MET']
     df_final_cohort_stats= df_joint_cohort_stats[new_cols]
+
+
+    # Impute the NaN value after join
+    df_final_cohort_stats['RELABUNDANCE_THRESHOLD_MET'] = df_final_cohort_stats['RELABUNDANCE_THRESHOLD_MET'].fillna(0)
+
+    # Prepare for boolean operation
+    df_final_cohort_stats['MAPPED_NTM_FRACTION_16S_THRESHOLD_MET'] = df_final_cohort_stats['MAPPED_NTM_FRACTION_16S_THRESHOLD_MET'].astype('Int64')
+    df_final_cohort_stats['COVERAGE_THRESHOLD_MET'] = df_final_cohort_stats['COVERAGE_THRESHOLD_MET'].astype('Int64')
+    df_final_cohort_stats['BREADTH_OF_COVERAGE_THRESHOLD_MET'] = df_final_cohort_stats['BREADTH_OF_COVERAGE_THRESHOLD_MET'].astype('Int64')
+    df_final_cohort_stats['RELABUNDANCE_THRESHOLD_MET'] = df_final_cohort_stats['RELABUNDANCE_THRESHOLD_MET'].astype('Int64')
+
+    # Derive the final threshold using Boolean operations
+    df_final_cohort_stats['ALL_THRESHOLDS_MET'] = df_final_cohort_stats['MAPPED_NTM_FRACTION_16S_THRESHOLD_MET'].astype('bool')  & df_final_cohort_stats['COVERAGE_THRESHOLD_MET'].astype('bool')  & df_final_cohort_stats['BREADTH_OF_COVERAGE_THRESHOLD_MET'].astype('bool')  & df_final_cohort_stats['RELABUNDANCE_THRESHOLD_MET'].astype('bool')
+    df_final_cohort_stats['ALL_THRESHOLDS_MET'] = df_final_cohort_stats['ALL_THRESHOLDS_MET'].replace({True: 1, False: 0})
+
+    # Write the final dataframe to file
     df_final_cohort_stats.to_csv(args['output_file'], sep="\t")

--- a/bin/sample_stats.py
+++ b/bin/sample_stats.py
@@ -10,15 +10,17 @@ re_mapped_p = re.compile(r'\d* mapped \((.*)%\)')
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Process the sample stats')
-    parser.add_argument('sample_name', metavar='sample_name', type=str, help='The sample name')
-    parser.add_argument('flagstat_file', metavar='flagstat_file', type=str, help='The flag stats file')
-    parser.add_argument('samtoolsstats_file', metavar='samtoolsstats_file', type=str, help='The samtools stats file')
-    parser.add_argument('wgsmetrics_file', metavar='wgsmetrics_file', type=str, help='The WGS metrics file')
-    parser.add_argument('ntmfraction_file', metavar='ntmfraction_file', type=str, help='The NTM fraction file')
-    parser.add_argument('median_coverage_cutoff', metavar='median_coverage_cutoff', default=10, type=float, help='The median coverage cutoff threshold')
-    parser.add_argument('breadth_of_coverage_cutoff', metavar='breadth_of_coverage_cutoff', default=0.9, type=float, help='The breadth of coverage cutoff threshold')
-    parser.add_argument('rel_abundance_cutoff', metavar='rel_abundance_cutoff', default=0.8, type=float, help='The relative abundance cutoff threshold')
-    parser.add_argument('ntm_fraction_cutoff', metavar='ntm_fraction_cutoff', default=0.2, type=float, help='The NTM fraction cutoff threshold')
+    parser.add_argument('--sample_name', dest='sample_name', required=True, metavar='sample_name', type=str, help='The sample name')
+    parser.add_argument('--flagstat_file', dest='flagstat_file', required=True, metavar='flagstat_file', type=str, help='The flag stats file')
+    parser.add_argument('--samtoolsstats_file', dest='samtoolsstats_file', required=True, metavar='samtoolsstats_file', type=str, help='The samtools stats file')
+    parser.add_argument('--wgsmetrics_file', dest='wgsmetrics_file', required=True, metavar='wgsmetrics_file', type=str, help='The WGS metrics file')
+    parser.add_argument('--ntmfraction_file', dest='ntmfraction_file', required=True, metavar='ntmfraction_file', type=str, help='The NTM fraction file')
+
+    parser.add_argument('--median_coverage_cutoff', metavar='median_coverage_cutoff', default=10, type=float, help='The median coverage cutoff threshold')
+    parser.add_argument('--breadth_of_coverage_cutoff', metavar='breadth_of_coverage_cutoff', default=0.9, type=float, help='The breadth of coverage cutoff threshold')
+    parser.add_argument('--rel_abundance_cutoff', metavar='rel_abundance_cutoff', default=0.8, type=float, help='The relative abundance cutoff threshold')
+    parser.add_argument('--ntm_fraction_cutoff', metavar='ntm_fraction_cutoff', default=0.2, type=float, help='The NTM fraction cutoff threshold')
+
     args = vars(parser.parse_args())
 
     with open(args['wgsmetrics_file']) as f:

--- a/bin/sample_stats.py
+++ b/bin/sample_stats.py
@@ -66,3 +66,4 @@ if __name__ == '__main__':
 
     with open('{}.stats.tsv'.format(args['sample_name']), 'w') as f:
         f.write('\t'.join([str(i) for i in [args['sample_name'], ins_size, mapped_p, total_seqs, avg_qual] + list(wgsmetrics.loc[0, ['MEAN_COVERAGE', 'SD_COVERAGE', 'MEDIAN_COVERAGE', 'MAD_COVERAGE', 'PCT_EXC_ADAPTER', 'PCT_EXC_MAPQ', 'PCT_EXC_DUPE', 'PCT_EXC_UNPAIRED', 'PCT_EXC_BASEQ', 'PCT_EXC_OVERLAP', 'PCT_EXC_CAPPED', 'PCT_EXC_TOTAL', 'PCT_1X', 'PCT_5X', 'PCT_10X', 'PCT_30X', 'PCT_50X', 'PCT_100X']]) + [ntm_fraction, ntm_fraction_threshold_met, coverage_threshold_met, breadth_of_coverage_threshold_met, all_thresholds_met]]))
+        f.write('\n')

--- a/bin/sample_stats.py
+++ b/bin/sample_stats.py
@@ -18,8 +18,10 @@ if __name__ == '__main__':
 
     parser.add_argument('--median_coverage_cutoff', metavar='median_coverage_cutoff', default=10, type=float, help='The median coverage cutoff threshold')
     parser.add_argument('--breadth_of_coverage_cutoff', metavar='breadth_of_coverage_cutoff', default=0.9, type=float, help='The breadth of coverage cutoff threshold')
-    parser.add_argument('--rel_abundance_cutoff', metavar='rel_abundance_cutoff', default=0.8, type=float, help='The relative abundance cutoff threshold')
     parser.add_argument('--ntm_fraction_cutoff', metavar='ntm_fraction_cutoff', default=0.2, type=float, help='The NTM fraction cutoff threshold')
+
+## NOTE: This is computed by the multiple_infection_filter script
+#    parser.add_argument('--rel_abundance_cutoff', metavar='rel_abundance_cutoff', default=0.8, type=float, help='The relative abundance cutoff threshold')
 
     args = vars(parser.parse_args())
 

--- a/bin/sample_stats.py
+++ b/bin/sample_stats.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import ast
+import argparse
+import re
+
+import pandas as pd
+
+re_mapped_p = re.compile(r'\d* mapped \((.*)%\)')
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Process the sample stats')
+    parser.add_argument('sample_name', metavar='sample_name', type=str, help='The sample name')
+    parser.add_argument('flagstat_file', metavar='flagstat_file', type=str, help='The flag stats file')
+    parser.add_argument('samtoolsstats_file', metavar='samtoolsstats_file', type=str, help='The samtools stats file')
+    parser.add_argument('wgsmetrics_file', metavar='wgsmetrics_file', type=str, help='The WGS metrics file')
+    parser.add_argument('ntmfraction_file', metavar='ntmfraction_file', type=str, help='The NTM fraction file')
+    parser.add_argument('median_coverage_cutoff', metavar='median_coverage_cutoff', default=10, type=float, help='The median coverage cutoff threshold')
+    parser.add_argument('breadth_of_coverage_cutoff', metavar='breadth_of_coverage_cutoff', default=0.9, type=float, help='The breadth of coverage cutoff threshold')
+    parser.add_argument('rel_abundance_cutoff', metavar='rel_abundance_cutoff', default=0.8, type=float, help='The relative abundance cutoff threshold')
+    parser.add_argument('ntm_fraction_cutoff', metavar='ntm_fraction_cutoff', default=0.2, type=float, help='The NTM fraction cutoff threshold')
+    args = vars(parser.parse_args())
+
+    with open(args['wgsmetrics_file']) as f:
+        for line in f:
+            if '## METRICS CLASS' in line:
+                rows = [f.readline().strip(), f.readline().strip()]
+                wgsmetrics = pd.DataFrame([rows[1].split('\t')], columns=rows[0].split('\t'))
+    with open(args['ntmfraction_file']) as f:
+        ntm_fraction = float(f.read().strip())
+    with open(args['samtoolsstats_file']) as f:
+        for line in f:
+            if 'insert size average' in line:
+                ins_size = float(line.strip().split('\t')[2])
+            if 'raw total sequences' in line:
+                total_seqs = int(line.strip().split('\t')[2])
+            if 'average quality' in line:
+                avg_qual = float(line.strip().split('\t')[2])
+    with open(args['flagstat_file']) as f:
+        for line in f:
+            m = re_mapped_p.match(line)
+            if m:
+                mapped_p = float(m[1])
+
+    if int(wgsmetrics.loc[0, 'MEDIAN_COVERAGE']) >= args['median_coverage_cutoff']:
+        coverage_threshold_met = 1
+    else:
+        coverage_threshold_met = 0
+
+    if float(wgsmetrics.loc[0, 'PCT_1X']) >= args['breadth_of_coverage_cutoff']:
+        breadth_of_coverage_threshold_met = 1
+    else:
+        breadth_of_coverage_threshold_met = 0
+
+    if ntm_fraction <= args['ntm_fraction_cutoff']:
+        ntm_fraction_threshold_met = 1
+    else:
+        ntm_fraction_threshold_met = 0
+
+    if coverage_threshold_met and breadth_of_coverage_threshold_met and ntm_fraction_threshold_met:
+        all_thresholds_met = 1
+    else:
+        all_thresholds_met = 0
+
+    with open('{}.stats.tsv'.format(args['sample_name']), 'w') as f:
+        f.write('\t'.join([str(i) for i in [args['sample_name'], ins_size, mapped_p, total_seqs, avg_qual] + list(wgsmetrics.loc[0, ['MEAN_COVERAGE', 'SD_COVERAGE', 'MEDIAN_COVERAGE', 'MAD_COVERAGE', 'PCT_EXC_ADAPTER', 'PCT_EXC_MAPQ', 'PCT_EXC_DUPE', 'PCT_EXC_UNPAIRED', 'PCT_EXC_BASEQ', 'PCT_EXC_OVERLAP', 'PCT_EXC_CAPPED', 'PCT_EXC_TOTAL', 'PCT_1X', 'PCT_5X', 'PCT_10X', 'PCT_30X', 'PCT_50X', 'PCT_100X']]) + [ntm_fraction, ntm_fraction_threshold_met, coverage_threshold_met, breadth_of_coverage_threshold_met, all_thresholds_met]]))

--- a/conda_envs/magma-env-1.yml
+++ b/conda_envs/magma-env-1.yml
@@ -14,3 +14,6 @@ dependencies:
   - bioconda::multiqc=1.11 
   - bioconda::fastqc=0.11.8
   - bioconda::fastq_utils=0.25.1
+  - conda-forge::bc=1.07.1
+  - conda-forge::sed=4.8
+  - conda-forge::grep=3.11

--- a/conda_envs/magma-env-2.yml
+++ b/conda_envs/magma-env-2.yml
@@ -13,3 +13,5 @@ dependencies:
   - bioconda::snpeff=4.3.1t 
   - bioconda::clusterpicker=1.2.3
   - conda-forge::bc=1.07.1
+  - conda-forge::sed=4.8
+  - conda-forge::grep=3.11

--- a/conf/podman.config
+++ b/conf/podman.config
@@ -1,0 +1,22 @@
+process {
+
+    //----------------------------------------------
+    // Custom containers for all deps.
+    //----------------------------------------------
+
+    withName:
+    'GATK.*|LOFREQ.*|DELLY.*|TBPROFILER.*|MULTIQC.*|FASTQC.*|UTILS.*|FASTQ.*|SAMPLESHEET.*' {
+        container = "ghcr.io/torch-consortium/magma/magma-container-1:1.1.0"
+    }
+
+    withName:
+    'BWA.*|IQTREE.*|SNPDISTS.*|SNPSITES.*|BCFTOOLS.*|BGZIP.*|SAMTOOLS.*|SNPEFF.*|CLUSTERPICKER.*' {
+        container = "ghcr.io/torch-consortium/magma/magma-container-2:1.1.0"
+    }
+
+}
+
+
+podman {
+    enabled = true
+}

--- a/default_params.config
+++ b/default_params.config
@@ -53,13 +53,10 @@ ntm_fraction_cutoff = 0.20
 // Set this to true if you'd like to only validate input fastqs
 only_validate_fastqs = false // OR true
 
-// Set this to true if you'd like to only validate input fastqs
-skip_merge_analysis = false // OR true
-
 // ##### EXPERIENCED USERS ##### 
 
-//Use this flag to skip the final merge
-skip_merge = false
+//Use this flag to skip the final merge analysis
+skip_merge_analysis = false // OR true
 
 // MAGMA optimises VQSR, if this messes up use the default settings for VQSR
 optimize_variant_recalibration = true

--- a/default_params.config
+++ b/default_params.config
@@ -22,18 +22,8 @@ use_ref_exit_rif_gvcf = false
 ref_exit_rif_gvcf =  "${projectDir}/resources/exit_rif/EXIT-RIF.g.vcf.gz" 
 ref_exit_rif_gvcf_tbi =  "${params.ref_exit_rif_gvcf}.tbi"
 
-// Enable Nextflow Tower for run monitoring by uncommenting and updating the follwoing section:
-// tower {
-//   enabled = true
-//   accessToken = '<YOUR TOKEN>'
-//   workspaceId = '<YOUR WORKSPACE ID>'
-// }
-
-
-
 
 // ##### The follow sections generally do not require adjusting. #####
-
 
 //  ##### QC THRESHOLDS ##### 
 
@@ -52,6 +42,7 @@ ntm_fraction_cutoff = 0.20
 
 // Set this to true if you'd like to only validate input fastqs
 only_validate_fastqs = false // OR true
+only_pre_merge_analysis = false // OR true
 
 // ##### EXPERIENCED USERS ##### 
 
@@ -292,10 +283,17 @@ DELLY_CALL {
     arguments = "-u 30"
 }
 
+TBPROFILER_PROFILE__BAM {
+    results_dir = "${params.outdir}/samples/variant_files/structural_variants/tbprofiler"
+}
 
-BCFTOOLS_VIEW {
-    results_dir = "${params.outdir}/samples/variant_files/structural_variants/delly"
+BCFTOOLS_VIEW__GATK {
+    results_dir = "${params.outdir}/samples/variant_files/structural_variants/gatk"
+}
 
+BCFTOOLS_VIEW__TBP {
+    results_dir = "${params.outdir}/samples/variant_files/structural_variants/tbprofiler"
+    arguments = """-i 'GT="1/1"'"""
 }
 
 GATK_INDEX_FEATURE_FILE__SV {
@@ -550,11 +548,17 @@ GATK_SELECT_VARIANTS__EXCLUSION__INDEL {
     arguments = " --select-type-to-include MNP --select-type-to-include MIXED "
 }
 
-BCFTOOLS_MERGE {
+BCFTOOLS_MERGE__LOFREQ {
     results_dir = "${params.outdir}/cohort/minor_variants/combined_variant_files/"
     should_publish = true
+    file_format = "lofreq"
 }
 
+BCFTOOLS_MERGE__DELLY {
+    results_dir = "${params.outdir}/cohort/minor_variants/combined_variant_files/"
+    should_publish = true
+    file_format = "delly"
+}
 
 GATK_MERGE_VCFS {
     results_dir = "${params.outdir}/cohort/combined_variant_files/"

--- a/main.nf
+++ b/main.nf
@@ -38,7 +38,7 @@ workflow {
 
         MINOR_VARIANTS_ANALYSIS_WF(CALL_WF.out.reformatted_lofreq_vcfs_tuple_ch)
 
-        STRUCTURAL_VARIANTS_ANALYSIS_WF ( CALL_WF.out.samtools_bam_ch )
+        //STRUCTURAL_VARIANTS_ANALYSIS_WF ( CALL_WF.out.samtools_bam_ch )
 
         UTILS_MERGE_COHORT_STATS ( MINOR_VARIANTS_ANALYSIS_WF.out.approved_samples_ch,
                                    MINOR_VARIANTS_ANALYSIS_WF.out.rejected_samples_ch,
@@ -59,6 +59,8 @@ workflow {
         MAP_WF( validated_reads_ch )
 
         CALL_WF( MAP_WF.out.sorted_reads_ch )
+
+        //STRUCTURAL_VARIANTS_ANALYSIS_WF ( CALL_WF.out.samtools_bam_ch )
 
         //NOTE: Samples implicitly get filtered in BCFTOOLS_MERGE if they don't have any identified variants
         MINOR_VARIANTS_ANALYSIS_WF(CALL_WF.out.reformatted_lofreq_vcfs_tuple_ch)

--- a/main.nf
+++ b/main.nf
@@ -25,7 +25,7 @@ workflow {
 
         VALIDATE_FASTQS_WF(params.input_samplesheet)
 
-    } else if (params.only_pre_merge_analysis) {
+    } else if (params.skip_merge_analysis) {
 
         validated_reads_ch = VALIDATE_FASTQS_WF( params.input_samplesheet )
 

--- a/main.nf
+++ b/main.nf
@@ -58,15 +58,16 @@ workflow {
 
         CALL_WF( MAP_WF.out.sorted_reads_ch )
 
+        //NOTE: Samples implicitly get filtered in BCFTOOLS_MERGE if they don't have any identified variants
         MINOR_VARIANT_ANALYSIS_WF(CALL_WF.out.reformatted_lofreq_vcfs_tuple_ch)
 
-        UTILS_MERGE_COHORT_STATS ( MINOR_VARIANT_ANALYSIS_WF.out.approved_samples_ch,
-                                   MINOR_VARIANT_ANALYSIS_WF.out.rejected_samples_ch,
-                                   CALL_WF.out.cohort_stats_tsv )
+        UTILS_MERGE_COHORT_STATS( MINOR_VARIANT_ANALYSIS_WF.out.approved_samples_ch,
+                                  MINOR_VARIANT_ANALYSIS_WF.out.rejected_samples_ch,
+                                  CALL_WF.out.cohort_stats_tsv )
 
         MERGE_WF( CALL_WF.out.gvcf_ch,
                   CALL_WF.out.reformatted_lofreq_vcfs_tuple_ch, 
-                  CALL_WF.out.cohort_stats_tsv,
+                  UTILS_MERGE_COHORT_STATS.out.merged_cohort_stats_ch,
                   MINOR_VARIANT_ANALYSIS_WF.out.approved_samples_ch,
                   MINOR_VARIANT_ANALYSIS_WF.out.rejected_samples_ch)
 

--- a/main.nf
+++ b/main.nf
@@ -10,9 +10,10 @@ include { CALL_WF } from './workflows/call_wf.nf'
 include { VALIDATE_FASTQS_WF } from './workflows/validate_fastqs_wf.nf'
 include { MAP_WF } from './workflows/map_wf.nf'
 include { MERGE_WF } from './workflows/merge_wf.nf'
-include { MINOR_VARIANT_ANALYSIS_WF } from './workflows/minor_variant_analysis_wf.nf'
+include { MINOR_VARIANTS_ANALYSIS_WF } from './workflows/minor_variants_analysis_wf.nf'
 include { QUALITY_CHECK_WF } from './workflows/quality_check_wf.nf'
 include { REPORTS_WF } from './workflows/reports_wf.nf'
+include { STRUCTURAL_VARIANTS_ANALYSIS_WF } from './workflows/structural_variants_analysis_wf.nf'
 include { UTILS_MERGE_COHORT_STATS } from "./modules/utils/merge_cohort_stats.nf" addParams ( params.UTILS_MERGE_COHORT_STATS )
 
 //================================================================================
@@ -35,10 +36,12 @@ workflow {
 
         CALL_WF( MAP_WF.out.sorted_reads_ch )
 
-        MINOR_VARIANT_ANALYSIS_WF(CALL_WF.out.reformatted_lofreq_vcfs_tuple_ch)
+        MINOR_VARIANTS_ANALYSIS_WF(CALL_WF.out.reformatted_lofreq_vcfs_tuple_ch)
 
-        UTILS_MERGE_COHORT_STATS ( MINOR_VARIANT_ANALYSIS_WF.out.approved_samples_ch,
-                                   MINOR_VARIANT_ANALYSIS_WF.out.rejected_samples_ch,
+        STRUCTURAL_VARIANTS_ANALYSIS_WF ( CALL_WF.out.samtools_bam_ch )
+
+        UTILS_MERGE_COHORT_STATS ( MINOR_VARIANTS_ANALYSIS_WF.out.approved_samples_ch,
+                                   MINOR_VARIANTS_ANALYSIS_WF.out.rejected_samples_ch,
                                    CALL_WF.out.cohort_stats_tsv )
 
 
@@ -48,7 +51,6 @@ workflow {
     /* } */
 
     } else {
-    //NOTE: If no --only* option specified, run the entire analysis
 
         validated_reads_ch = VALIDATE_FASTQS_WF( params.input_samplesheet )
 
@@ -72,11 +74,10 @@ workflow {
                   MINOR_VARIANT_ANALYSIS_WF.out.rejected_samples_ch)
 
         REPORTS_WF(QUALITY_CHECK_WF.out.reports_fastqc_ch,
-                   MINOR_VARIANT_ANALYSIS_WF.out.minor_variants_results_ch,
+                   MINOR_VARIANTS_ANALYSIS_WF.out.minor_variants_results_ch,
                    MERGE_WF.out.major_variants_results_ch)
 
         }
 
 }
-
 

--- a/main.nf
+++ b/main.nf
@@ -61,17 +61,17 @@ workflow {
         CALL_WF( MAP_WF.out.sorted_reads_ch )
 
         //NOTE: Samples implicitly get filtered in BCFTOOLS_MERGE if they don't have any identified variants
-        MINOR_VARIANT_ANALYSIS_WF(CALL_WF.out.reformatted_lofreq_vcfs_tuple_ch)
+        MINOR_VARIANTS_ANALYSIS_WF(CALL_WF.out.reformatted_lofreq_vcfs_tuple_ch)
 
-        UTILS_MERGE_COHORT_STATS( MINOR_VARIANT_ANALYSIS_WF.out.approved_samples_ch,
-                                  MINOR_VARIANT_ANALYSIS_WF.out.rejected_samples_ch,
+        UTILS_MERGE_COHORT_STATS( MINOR_VARIANTS_ANALYSIS_WF.out.approved_samples_ch,
+                                  MINOR_VARIANTS_ANALYSIS_WF.out.rejected_samples_ch,
                                   CALL_WF.out.cohort_stats_tsv )
 
         MERGE_WF( CALL_WF.out.gvcf_ch,
                   CALL_WF.out.reformatted_lofreq_vcfs_tuple_ch, 
                   UTILS_MERGE_COHORT_STATS.out.merged_cohort_stats_ch,
-                  MINOR_VARIANT_ANALYSIS_WF.out.approved_samples_ch,
-                  MINOR_VARIANT_ANALYSIS_WF.out.rejected_samples_ch)
+                  MINOR_VARIANTS_ANALYSIS_WF.out.approved_samples_ch,
+                  MINOR_VARIANTS_ANALYSIS_WF.out.rejected_samples_ch)
 
         REPORTS_WF(QUALITY_CHECK_WF.out.reports_fastqc_ch,
                    MINOR_VARIANTS_ANALYSIS_WF.out.minor_variants_results_ch,

--- a/modules/bcftools/merge.nf
+++ b/modules/bcftools/merge.nf
@@ -7,18 +7,22 @@ process BCFTOOLS_MERGE {
         path("*")
 
     output:
-        tuple val(params.vcf_name), path("*.LoFreq.vcf")
+        tuple val(params.vcf_name), path("*.${params.file_format}.vcf.gz"), path("*.vcf.gz.csi")
+
 
     script:
 
         """
-        bcftools merge -o ${params.vcf_name}.LoFreq.vcf ${vcfs_string_ch}
+        bcftools merge -o ${params.vcf_name}.${params.file_format}.vcf ${vcfs_string_ch}
+        bgzip ${params.vcf_name}.${params.file_format}.vcf
+        ${params.bcftools_path} index ${params.vcf_name}.${params.file_format}.vcf.gz
         """
 
     stub:
 
         """
-        touch ${params.vcf_name}.LoFreq.vcf
+        touch ${params.vcf_name}.${params.file_format}.vcf.gz
+        touch ${params.vcf_name}.${params.file_format}.vcf.gz.csi
         """
 
 }

--- a/modules/bcftools/view__gatk.nf
+++ b/modules/bcftools/view__gatk.nf
@@ -1,4 +1,4 @@
-process BCFTOOLS_VIEW {
+process BCFTOOLS_VIEW__GATK {
     tag "${sampleName}"
     publishDir params.results_dir, mode: params.save_mode, enabled: params.should_publish
 

--- a/modules/bcftools/view__tbp.nf
+++ b/modules/bcftools/view__tbp.nf
@@ -1,0 +1,26 @@
+process BCFTOOLS_VIEW__TBP {
+    tag "${sampleName}"
+    publishDir params.results_dir, mode: params.save_mode, enabled: params.should_publish
+
+    input:
+        tuple val(sampleName), path(bcf)
+
+    output:
+        tuple val(sampleName), path("*.bcf.gz"), path("*.bcf.gz.csi")
+
+    shell:
+
+        '''
+        !{params.bcftools_path} view !{params.arguments}  !{sampleName}.delly.bcf -o !{sampleName}.filtered.delly.bcf
+        bgzip !{sampleName}.filtered.delly.bcf
+        !{params.bcftools_path} index !{sampleName}.filtered.delly.bcf.gz
+        '''
+
+    stub:
+
+        """
+        touch ${sampleName}.bcf.gz
+        touch ${sampleName}.bcf.gz.csi
+        """
+
+}

--- a/modules/tbprofiler/profile__bam.nf
+++ b/modules/tbprofiler/profile__bam.nf
@@ -1,0 +1,30 @@
+process TBPROFILER_PROFILE__BAM {
+    tag "${sampleName}"
+    publishDir params.results_dir, mode: params.save_mode, enabled: params.should_publish, pattern: "vcf/*vcf.gz", saveAs: { f -> f.tokenize("/").last()}
+    publishDir params.results_dir, mode: params.save_mode, enabled: params.should_publish, pattern: "vcf/*bcf", saveAs: { f -> f.tokenize("/").last()}
+
+
+    input:
+        tuple val(sampleName), path("*.bai"), path(bam)
+        path(resistanceDb)
+
+    output:
+        tuple val(sampleName), path("vcf/*"), emit: per_sample_results
+
+    script:
+        def optionalDb  = resistanceDb ? "--db ${resistanceDb}" : ""
+
+        """
+        ${params.tbprofiler_path} profile \\
+            -a ${bam} \\
+            ${optionalDb} \\
+            -p ${sampleName}
+        """
+
+    stub:
+        """
+        touch ${sampleName}.txt
+        """
+}
+
+

--- a/modules/tbprofiler/vcf_profile__lofreq.nf
+++ b/modules/tbprofiler/vcf_profile__lofreq.nf
@@ -3,7 +3,7 @@ process TBPROFILER_VCF_PROFILE__LOFREQ {
     publishDir params.results_dir, mode: params.save_mode, enabled: params.should_publish
 
     input:
-        tuple val(name), path(mergedLofreqVcf)
+        tuple val(name), path(mergedLofreqVcf), path(mergedLofreqVcfIndex)
         path(resistanceDb)
 
     output:

--- a/modules/utils/merge_cohort_stats.nf
+++ b/modules/utils/merge_cohort_stats.nf
@@ -8,7 +8,7 @@ process UTILS_MERGE_COHORT_STATS {
         path(call_wf_cohort_stats_tsv)
 
     output:
-        path("*merged_cohort_stats.tsv")
+        path("*merged_cohort_stats.tsv"),    emit: merged_cohort_stats_ch
 
 
     script:

--- a/modules/utils/sample_stats.nf
+++ b/modules/utils/sample_stats.nf
@@ -18,8 +18,8 @@ process UTILS_SAMPLE_STATS {
             --ntmfraction_file ${ntmFraction} \\
             --median_coverage_cutoff ${params.median_coverage_cutoff} \\
             --breadth_of_coverage_cutoff ${params.breadth_of_coverage_cutoff} \\
-            --rel_abundance_cutoff ${rel_abundance_cutoff} \\
-            --ntm_fraction_cutoff ${ntm_fraction_cutoff}
+            --rel_abundance_cutoff ${params.rel_abundance_cutoff} \\
+            --ntm_fraction_cutoff ${params.ntm_fraction_cutoff}
         """
 
 }

--- a/modules/utils/sample_stats.nf
+++ b/modules/utils/sample_stats.nf
@@ -18,7 +18,6 @@ process UTILS_SAMPLE_STATS {
             --ntmfraction_file ${ntmFraction} \\
             --median_coverage_cutoff ${params.median_coverage_cutoff} \\
             --breadth_of_coverage_cutoff ${params.breadth_of_coverage_cutoff} \\
-            --rel_abundance_cutoff ${params.rel_abundance_cutoff} \\
             --ntm_fraction_cutoff ${params.ntm_fraction_cutoff}
         """
 

--- a/modules/utils/sample_stats.nf
+++ b/modules/utils/sample_stats.nf
@@ -8,64 +8,18 @@ process UTILS_SAMPLE_STATS {
     output:
         path("*.stats.tsv")
 
+    script:
+        """
+        sample_stats.py \\
+            --sample_name ${sampleName} \\
+            --flagstat_file ${flagStats}  \\
+            --samtoolsstats_file ${samtoolsStats} \\
+            --wgsmetrics_file ${wgsMetrics} \\
+            --ntmfraction_file ${ntmFraction} \\
+            --median_coverage_cutoff ${params.median_coverage_cutoff} \\
+            --breadth_of_coverage_cutoff ${params.breadth_of_coverage_cutoff} \\
+            --rel_abundance_cutoff ${rel_abundance_cutoff} \\
+            --ntm_fraction_cutoff ${ntm_fraction_cutoff}
+        """
 
-    shell:
-
-        '''
-
-        # This function checks whether the NTM fraction threshold is met for one of the strains
-        function ntm_fraction_threshold_met () {
-            IFS=';'
-            local i
-            for i in ${@:2}
-            do
-                if [ 1 -eq "$(echo "$i <= $1" | bc)" ]
-                then
-                    IFS=' '
-                    echo 1 # Return 1 because the sample passed the stats
-                    return 0 # set a zero exitcode for if branching (i.e. this function passed)
-                fi
-            done
-            IFS=' '
-            echo 0 # Return 0 because the sample did not pass the stats
-            return 1 # set a nonzero returncode to fail if statements
-        }
-
-        IFS=' '
-
-        COVERAGE=$(cat !{wgsMetrics} | grep "^4411532" | cut -f 4)
-        BREADTH_OF_COVERAGE=$(cat !{wgsMetrics} | grep "^4411532" | cut -f 14)
-        TOTAL_SEQS=$(cat !{samtoolsStats} | grep "insert size average" | cut -f 3)
-        MAPPED_P=$(cat !{flagStats} | grep "mapped (" | cut -f 2 -d "(" | cut -f 1 -d "%")
-        INS_SIZE=$(cat !{samtoolsStats} | grep "raw total sequences" | cut -f 3)
-        AVG_QUAL=$(cat !{samtoolsStats} | grep "average quality" | cut -f 3)
-        WGS_METR=$(cat !{wgsMetrics} | grep "^4411532" | cut -f 2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,20,22,27)
-        NTM_FRACTION=$(cat !{ntmFraction})
-
-        if [ $COVERAGE -ge !{params.median_coverage_cutoff} ]
-            then
-                COVERAGE_THRESHOLD_MET=1
-            else
-                COVERAGE_THRESHOLD_MET=0
-        fi
-
-
-        if [ 1 -eq "$(echo "$BREADTH_OF_COVERAGE >= !{params.breadth_of_coverage_cutoff}" | bc)" ]
-            then
-                BREADTH_OF_COVERAGE_THRESHOLD_MET=1
-            else
-                BREADTH_OF_COVERAGE_THRESHOLD_MET=0
-        fi
-
-
-        if [ $COVERAGE -ge !{params.median_coverage_cutoff} ] && [ 1 -eq "$(echo "$BREADTH_OF_COVERAGE >= !{params.breadth_of_coverage_cutoff}" | bc)" ] && ntm_fraction_threshold_met !{params.ntm_fraction_cutoff} $NTM_FRACTION;
-            then
-                ALL_THRESHOLDS_MET=1
-            else
-                ALL_THRESHOLDS_MET=0
-        fi
-
-
-        echo -e "!{sampleName}\t${TOTAL_SEQS}\t${MAPPED_P}\t${INS_SIZE}\t${AVG_QUAL}\t${WGS_METR}\t${NTM_FRACTION}\t$(ntm_fraction_threshold_met !{params.ntm_fraction_cutoff} $NTM_FRACTION)\t${COVERAGE_THRESHOLD_MET}\t${BREADTH_OF_COVERAGE_THRESHOLD_MET}\t${ALL_THRESHOLDS_MET}" > !{sampleName}.stats.tsv
-        '''
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -57,6 +57,7 @@ profiles {
     // Package management specific settings
     conda_local { includeConfig 'conf/conda_local.config' }
     docker { includeConfig 'conf/docker.config' }
+    podman { includeConfig 'conf/podman.config' }
 
     // Executor specific settings
     pbs { includeConfig 'conf/pbs.config' }

--- a/workflows/call_wf.nf
+++ b/workflows/call_wf.nf
@@ -137,12 +137,12 @@ workflow CALL_WF {
 
         UTILS_SAMPLE_STATS(sample_stats_ch)
 
-        UTILS_COHORT_STATS(UTILS_SAMPLE_STATS.out.collect(sort:true))
+        UTILS_COHORT_STATS(UTILS_SAMPLE_STATS.out.collect())
 
     emit:
         cohort_stats_tsv = UTILS_COHORT_STATS.out
-        gvcf_ch = GATK_HAPLOTYPE_CALLER.out.gvcf_ch.collect(sort:true)
+        gvcf_ch = GATK_HAPLOTYPE_CALLER.out.gvcf_ch.collect()
         reformatted_lofreq_vcfs_tuple_ch = GATK_INDEX_FEATURE_FILE__LOFREQ.out.vcf_tuple.collect(sort:true)
-        bgzip_ch = BGZIP__LOFREQ.out.collect(sort:true) 
+        bgzip_ch = BGZIP__LOFREQ.out.collect() 
         samtools_bam_ch = SAMTOOLS_INDEX.out 
 }

--- a/workflows/call_wf.nf
+++ b/workflows/call_wf.nf
@@ -137,12 +137,12 @@ workflow CALL_WF {
 
         UTILS_SAMPLE_STATS(sample_stats_ch)
 
-        UTILS_COHORT_STATS(UTILS_SAMPLE_STATS.out.collect())
+        UTILS_COHORT_STATS(UTILS_SAMPLE_STATS.out.collect(sort:true))
 
     emit:
         cohort_stats_tsv = UTILS_COHORT_STATS.out
-        gvcf_ch = GATK_HAPLOTYPE_CALLER.out.gvcf_ch.collect()
+        gvcf_ch = GATK_HAPLOTYPE_CALLER.out.gvcf_ch.collect(sort:true)
         reformatted_lofreq_vcfs_tuple_ch = GATK_INDEX_FEATURE_FILE__LOFREQ.out.vcf_tuple.collect(sort:true)
-        bgzip_ch = BGZIP__LOFREQ.out.collect() 
+        bgzip_ch = BGZIP__LOFREQ.out.collect(sort:true) 
         samtools_bam_ch = SAMTOOLS_INDEX.out 
 }

--- a/workflows/merge_wf.nf
+++ b/workflows/merge_wf.nf
@@ -14,7 +14,7 @@ workflow MERGE_WF {
     take:
         gvcf_ch
         reformatted_lofreq_vcfs_tuple_ch
-        cohort_stats_tsv
+        merged_cohort_stats_tsv
         approved_samples_ch
         rejected_samples_ch
 
@@ -42,7 +42,7 @@ workflow MERGE_WF {
 
         //NOTE: Use the stats file for the entire cohort (from CALL_WF)
         // and filter out the samples which pass all thresholds
-        approved_call_wf_samples_ch = cohort_stats_tsv
+        approved_call_wf_samples_ch = merged_cohort_stats_tsv
                                 .splitCsv(header: false, skip: 1, sep: '\t' )
                                 .map { row -> [
                                         row.first(),           // SAMPLE

--- a/workflows/merge_wf.nf
+++ b/workflows/merge_wf.nf
@@ -57,7 +57,7 @@ workflow MERGE_WF {
         /*         .collect() */
         /*         .dump(tag:'approved_call_wf_samples_ch.collect()') */
 
-        //NOTE: Join the approved samples from MINOR_VARIANT_ANALYSIS_WF and CALL_WF
+        //NOTE: Join the approved samples from MINOR_VARIANTS_ANALYSIS_WF and CALL_WF
         fully_approved_samples_ch = approved_samples_minor_variants_ch
                                         .join(approved_call_wf_samples_ch)
                                         .flatten()
@@ -72,6 +72,7 @@ workflow MERGE_WF {
                                         .dump(tag:'MERGE_WF: selected_gvcfs_ch', pretty: true)
 
         //NOTE: Filter only file type values and send to MERGE_WF
+        //FIXME refactor the filtering logic NOT to rely upon the exact classnames
         filtered_selected_gvcfs_ch = selected_gvcfs_ch
                                         .filter { it -> { 
                                                             (it.class.name  == "sun.nio.fs.UnixPath") 

--- a/workflows/minor_variant_analysis_wf.nf
+++ b/workflows/minor_variant_analysis_wf.nf
@@ -19,6 +19,7 @@ workflow MINOR_VARIANT_ANALYSIS_WF {
                                 .reduce { a, b -> "$a $b " }
                                 .dump(tag:'MINOR_VARIANT_WF: vcfs_string_ch', pretty: true)
 
+        //NOTE: Samples implicitly get filtered here if they don't have any identified variants
         BCFTOOLS_MERGE(vcfs_string_ch, reformatted_lofreq_vcfs_tuple_ch)
 
         // merge_call_resistance_lofreq

--- a/workflows/structural_variants_analysis_wf.nf
+++ b/workflows/structural_variants_analysis_wf.nf
@@ -1,0 +1,68 @@
+include { BGZIP } from "../modules/bgzip/bgzip.nf" addParams( params.BGZIP__MINOR_VARIANTS )
+include { DELLY_CALL } from "../modules/delly/call.nf" addParams ( params.DELLY_CALL )
+include { BCFTOOLS_VIEW__GATK} from "../modules/bcftools/view__gatk.nf" addParams ( params.BCFTOOLS_VIEW__GATK )
+include { BCFTOOLS_VIEW__TBP } from "../modules/bcftools/view__tbp.nf" addParams ( params.BCFTOOLS_VIEW__TBP )
+include { BCFTOOLS_MERGE as  BCFTOOLS_MERGE__DELLY } from "../modules/bcftools/merge.nf" addParams ( params.BCFTOOLS_MERGE__DELLY )
+include { GATK_INDEX_FEATURE_FILE as GATK_INDEX_FEATURE_FILE__SV } from "../modules/gatk/index_feature_file.nf" addParams ( params.GATK_INDEX_FEATURE_FILE__SV )
+include { GATK_SELECT_VARIANTS__INCLUSION } from "../modules/gatk/select_variants__intervals.nf" addParams ( params.GATK_SELECT_VARIANTS__INCLUSION )
+include { TBPROFILER_PROFILE__BAM } from "../modules/tbprofiler/profile__bam.nf" addParams (params.TBPROFILER_PROFILE__BAM)
+
+workflow STRUCTURAL_VARIANTS_ANALYSIS_WF {
+
+    take:
+        samtools_bams_ch
+
+    main:
+
+        //----------------------------------------------------------------------------------
+        // Infer structural variants
+        //
+        //NOTE: This inference can not handle a contaminant and MTB allele on the same site.
+        //if so the site will be excluded.
+        //----------------------------------------------------------------------------------
+
+        DELLY_CALL(samtools_bams_ch, params.ref_fasta)
+
+        BCFTOOLS_VIEW__GATK(DELLY_CALL.out)
+        GATK_INDEX_FEATURE_FILE__SV(BCFTOOLS_VIEW__GATK.out, 'potentialSV')
+        GATK_SELECT_VARIANTS__INCLUSION(GATK_INDEX_FEATURE_FILE__SV.out.sample_vcf_tuple, params.drgenes_list)
+
+        BCFTOOLS_VIEW__TBP(DELLY_CALL.out)
+
+//FIXME save the string to an intermediate file
+
+        vcfs_and_indexes_ch = BCFTOOLS_VIEW__TBP.out
+                                .collect(sort: true)
+                                .flatten()
+                                .filter { it.class.name  != "java.lang.String" }
+                                .collect(sort: true)
+                                //.view{ it }
+
+        vcfs_string_ch = BCFTOOLS_VIEW__TBP.out
+                                .collect(sort: true)
+                                .flatten()
+                                .filter { it.class.name  != "java.lang.String" }
+                                .filter { it.extension  == "gz" }
+                                .map { it -> it.name }
+                                .reduce { a, b -> "$a $b " }
+                                //.view { it }
+                                //.dump(tag:'MINOR_VARIANT_WF: vcfs_string_ch', pretty: true)
+
+
+        BCFTOOLS_MERGE__DELLY(vcfs_string_ch, vcfs_and_indexes_ch)
+
+        // merge_call_resistance_lofreq
+        //BGZIP(BCFTOOLS_MERGE.out) 
+
+        def resistanceDb =  params.resistance_db != "NONE" ?  params.resistance_db : []
+
+        bams_ch = samtools_bams_ch
+                        .collect()
+                        .flatten()
+                        .collate(3)
+                        //.dump(tag:"STRUCTURAL_VARIANTS_ANALYSIS_WF")
+
+
+        TBPROFILER_PROFILE__BAM(bams_ch, resistanceDb)
+
+}

--- a/workflows/subworkflows/phylogeny_analysis.nf
+++ b/workflows/subworkflows/phylogeny_analysis.nf
@@ -24,21 +24,21 @@ workflow PHYLOGENY_ANALYSIS {
                     }
                 }
             }
-            .dump(tag: "PHYLOGENY_ANALYSIS args_ch: ", pretty: true)
+            //.dump(tag: "PHYLOGENY_ANALYSIS args_ch: ", pretty: true)
 
 
         resources_files_ch = arg_files_ch
             .filter {  (it.getExtension()  == "gz") || (it.getExtension()  == "list") }
             .collect()
             .ifEmpty([])
-            .dump(tag: "PHYLOGENY_ANALYSIS resources_files_ch: ", pretty: true)
+            //.dump(tag: "PHYLOGENY_ANALYSIS resources_files_ch: ", pretty: true)
 
 
         resources_file_indexes_ch = arg_files_ch
             .filter {  it.getExtension()  == "tbi" }
             .collect()
             .ifEmpty([])
-            .dump(tag: "PHYLOGENY_ANALYSIS resources_file_indexes_ch: ", pretty: true)
+            //.dump(tag: "PHYLOGENY_ANALYSIS resources_file_indexes_ch: ", pretty: true)
 
 
         // merge_phylogeny_prep_inccomplex


### PR DESCRIPTION
## CHANGES

This PR implements a revamp of stats computation logic
- Moves the computation logic from shell script (and GNU tools) to Python (Thanks @LennertVerboven )
- Combines the generated TSV files using pandas (updated logic)
- Recomputes the `ALL_THRESHOLDS_MET` logic  

## TESTING

Please rely upon 

- Pulling the code directly from Github as highlighted here https://github.com/TORCH-Consortium/MAGMA/pull/134#issue-1437164085

- The `-r abhinav/stats-computation -latest` branch for testing with the latest code in the branch with the updates.

- The `only_pre_merge_analysis` parameter has been renamed to `skip_merge_analysis` 
