### PR TITLE
Rethink FASTQ validation and accommodate FusionFS 

### DIFF
--- a/bin/summarize_resistance.py
+++ b/bin/summarize_resistance.py
@@ -90,6 +90,11 @@ if __name__ == '__main__':
     if not os.path.exists(dir_summary):
         os.makedirs(dir_summary)
 
+    dir_summary_json = args['summary_output_dir'] + "/json_format"
+    if not os.path.exists(dir_summary_json):
+        os.makedirs(dir_summary_json)
+
+
     samples = {}
 
     dir_major_vars = args['major_res_var_dir'] + "/" + 'results'
@@ -163,6 +168,11 @@ if __name__ == '__main__':
             pt_df[column] = pt_df[column].apply(lambda c: map_resistance_class[-1] if c == unknown_positions else None if pd.isna(c) else map_resistance_class[c])
 
         pt_df = pt_df[['Drug', 'Conclusion', 'Variant', 'Resistance interpretation', 'Type', 'Frequency', 'Method', 'Literature', 'Source notation']]
+
+        # Write a json output
+        json_data = pt_df.to_json()
+        with open(os.path.join(dir_summary_json, '{}.json'.format(patient)), 'w') as f:
+            f.write(json_data)
 
         # Write the sheet to excel with formatting
         with pd.ExcelWriter(os.path.join(dir_summary, '{}.xlsx'.format(patient)), engine='xlsxwriter') as writer:

--- a/bin/summarize_resistance.py
+++ b/bin/summarize_resistance.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+import glob
 import json
 import os
 import re
@@ -86,37 +86,38 @@ if __name__ == '__main__':
     parser.add_argument('summary_output_dir', metavar='summary_output_dir', type=str, help='The directory where the resulting excel sheets should be placed')
     args = vars(parser.parse_args())
 
-    summary_dir = args['summary_output_dir']
-    if not os.path.exists(summary_dir):
-        os.makedirs(summary_dir)
+    dir_summary = args['summary_output_dir']
+    if not os.path.exists(dir_summary):
+        os.makedirs(dir_summary)
 
     samples = {}
-    for file_name in os.listdir(os.path.join(args['major_res_var_dir'], 'results')):
-        if file_name == '.DS_Store':
-            continue
-        keys = '.'.join(file_name.split('.')[:-2])
+
+    dir_major_vars = args['major_res_var_dir'] + "/" + 'results'
+    json_major_vars = glob.glob(dir_major_vars + "/" + "*.json")
+    for file_name in json_major_vars:
+        keys = '.'.join(file_name.split('.')[:-2]).split('/')[-1]
         samples[keys] = {}
-        with open(os.path.join(os.path.join(args['major_res_var_dir'], 'results', file_name))) as json_file:
+        with open(file_name) as json_file:
             samples[keys]['magma'] = json.load(json_file)
 
-    if os.path.exists(os.path.join(os.path.join(args['minor_res_var_dir'], 'results'))):
-        for file_name in os.listdir(os.path.join(os.path.join(args['minor_res_var_dir'], 'results'))):
-            if file_name == '.DS_Store':
-                continue
-            keys = '.'.join(file_name.split('.')[:-2])
+    dir_minor_vars = args['minor_res_var_dir'] + "/" + 'results'
+    if os.path.exists(dir_minor_vars):
+        json_minor_vars = glob.glob(dir_minor_vars + "/" + "*.json")
+        for file_name in json_minor_vars:
+            keys = '.'.join(file_name.split('.')[:-2]).split('/')[-1]
             if keys not in samples:
                 continue
-            with open(os.path.join(os.path.join(os.path.join(args['minor_res_var_dir'], 'results', file_name)))) as json_file:
+            with open(file_name) as json_file:
                 samples[keys]['lofreq'] = json.load(json_file)
 
-    if os.path.exists(os.path.join(os.path.join(args['struc_res_var_dir'], 'results'))):
-        for file_name in os.listdir(os.path.join(os.path.join(args['struc_res_var_dir'], 'results'))):
-            if file_name == '.DS_Store':
-                continue
-            keys = '.'.join(file_name.split('.')[:-2])
+    dir_struc_vars = args['struc_res_var_dir'] + "/" + 'results'
+    if os.path.exists(dir_struc_vars):
+        json_struc_vars = glob.glob(dir_struc_vars + "/" + "*.json")
+        for file_name in json_struc_vars:
+            keys = '.'.join(file_name.split('.')[:-2]).split('/')[-1]
             if keys not in samples:
                 continue
-            with open(os.path.join(os.path.join(os.path.join(args['struc_res_var_dir'], 'results', file_name)))) as json_file:
+            with open(file_name) as json_file:
                 samples[keys]['delly'] = json.load(json_file)
 
 #===============
@@ -164,7 +165,7 @@ if __name__ == '__main__':
         pt_df = pt_df[['Drug', 'Conclusion', 'Variant', 'Resistance interpretation', 'Type', 'Frequency', 'Method', 'Literature', 'Source notation']]
 
         # Write the sheet to excel with formatting
-        with pd.ExcelWriter(os.path.join(summary_dir, '{}.xlsx'.format(patient)), engine='xlsxwriter') as writer:
+        with pd.ExcelWriter(os.path.join(dir_summary, '{}.xlsx'.format(patient)), engine='xlsxwriter') as writer:
             pt_df.set_index(['Drug', 'Conclusion', 'Variant']).to_excel(writer, sheet_name='resistance_variants')
 
             format_sens = writer.book.add_format({'bold': False, 'font_color': 'green'})

--- a/bin/summarize_resistance_mixed_infection.py
+++ b/bin/summarize_resistance_mixed_infection.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+import glob
 import json
 import os
 import re
@@ -108,27 +108,31 @@ if __name__ == '__main__':
     parser.add_argument('summary_output_dir', metavar='summary_output_dir', type=str, help='The directory where the resulting CSV files should be placed')
     args = vars(parser.parse_args())
 
-    summary_dir = args['summary_output_dir']
-    if not os.path.exists(summary_dir):
-        os.makedirs(summary_dir)
+    dir_summary = args['summary_output_dir']
+    if not os.path.exists(dir_summary):
+        os.makedirs(dir_summary)
 
     samples = {}
-    for file_name in os.listdir(os.path.join(args['minor_res_var_dir'], 'results')):
-        if file_name == '.DS_Store':
-            continue
-        keys = '.'.join(file_name.split('.')[:-2])
-        samples[keys] = {}
-        with open(os.path.join(args['minor_res_var_dir'], 'results', file_name)) as json_file:
-            samples[keys]['lofreq'] = json.load(json_file)
 
-    if os.path.exists(os.path.join(args['struc_res_var_dir'], 'results')):
-        for file_name in os.listdir(os.path.join(args['struc_res_var_dir'], 'results')):
-            if file_name == '.DS_Store':
-                continue
-            keys = '.'.join(file_name.split('.')[:-2])
+    dir_minor_vars = args['minor_res_var_dir'] + "/" + 'results'
+    if os.path.exists(dir_minor_vars):
+        json_minor_vars = glob.glob(dir_minor_vars + "/" + "*.json")
+        for file_name in json_minor_vars:
+            keys = '.'.join(file_name.split('.')[:-2]).split('/')[-1]
             if keys not in samples:
                 continue
-            with open(os.path.join(args['struc_res_var_dir'], 'results', file_name)) as json_file:
+            with open(file_name) as json_file:
+                samples[keys]['lofreq'] = json.load(json_file)
+
+
+    dir_struc_vars = args['struc_res_var_dir'] + "/" + 'results'
+    if os.path.exists(dir_struc_vars):
+        json_struc_vars = glob.glob(dir_struc_vars + "/" + "*.json")
+        for file_name in json_struc_vars:
+            keys = '.'.join(file_name.split('.')[:-2]).split('/')[-1]
+            if keys not in samples:
+                continue
+            with open(file_name) as json_file:
                 samples[keys]['delly'] = json.load(json_file)
 
 #===============

--- a/bin/summarize_resistance_mixed_infection.py
+++ b/bin/summarize_resistance_mixed_infection.py
@@ -112,17 +112,19 @@ if __name__ == '__main__':
     if not os.path.exists(dir_summary):
         os.makedirs(dir_summary)
 
+    dir_summary_json = args['summary_output_dir'] + "/json_format"
+    if not os.path.exists(dir_summary_json):
+        os.makedirs(dir_summary_json)
+
     samples = {}
 
     dir_minor_vars = args['minor_res_var_dir'] + "/" + 'results'
-    if os.path.exists(dir_minor_vars):
-        json_minor_vars = glob.glob(dir_minor_vars + "/" + "*.json")
-        for file_name in json_minor_vars:
-            keys = '.'.join(file_name.split('.')[:-2]).split('/')[-1]
-            if keys not in samples:
-                continue
-            with open(file_name) as json_file:
-                samples[keys]['lofreq'] = json.load(json_file)
+    json_minor_vars = glob.glob(dir_minor_vars + "/" + "*.json")
+    for file_name in json_minor_vars:
+        keys = '.'.join(file_name.split('.')[:-2]).split('/')[-1]
+        samples[keys] = {}
+        with open(file_name) as json_file:
+            samples[keys]['lofreq'] = json.load(json_file)
 
 
     dir_struc_vars = args['struc_res_var_dir'] + "/" + 'results'
@@ -178,8 +180,13 @@ if __name__ == '__main__':
 
         pt_df = pt_df[['Drug', 'Conclusion', 'Variant', 'Resistance interpretation', 'Type', 'Frequency', 'Method', 'Literature', 'Source notation']]
 
+        # Write a json output
+        json_data = pt_df.to_json()
+        with open(os.path.join(dir_summary_json, '{}.json'.format(patient)), 'w') as f:
+            f.write(json_data)
+
         # Write the sheet to excel with formatting
-        with pd.ExcelWriter(os.path.join(summary_dir, '{}.xlsx'.format(patient)), engine='xlsxwriter') as writer:
+        with pd.ExcelWriter(os.path.join(dir_summary, '{}.xlsx'.format(patient)), engine='xlsxwriter') as writer:
             pt_df.set_index(['Drug', 'Conclusion', 'Variant']).to_excel(writer, sheet_name='resistance_variants')  # Updated sheet name
 
             format_sens = writer.book.add_format({'bold': False, 'font_color': 'green'})

--- a/main.nf
+++ b/main.nf
@@ -26,9 +26,9 @@ workflow {
 
     if (params.only_validate_fastqs) {
 
-        SAMPLESHEET_VALIDATION(params.input_samplesheet)
+        SAMPLESHEET_VALIDATION( params.input_samplesheet )
 
-        validated_reads_ch = VALIDATE_FASTQS_WF( params.input_samplesheet , SAMPLESHEET_VALIDATION.out )
+        validated_reads_ch = VALIDATE_FASTQS_WF( params.input_samplesheet , SAMPLESHEET_VALIDATION.out.status )
 
         QUALITY_CHECK_WF( validated_reads_ch )
 
@@ -39,7 +39,7 @@ workflow {
 
         SAMPLESHEET_VALIDATION(params.input_samplesheet)
 
-        validated_reads_ch = VALIDATE_FASTQS_WF( params.input_samplesheet , SAMPLESHEET_VALIDATION.out )
+        validated_reads_ch = VALIDATE_FASTQS_WF( params.input_samplesheet , SAMPLESHEET_VALIDATION.out.status )
 
         QUALITY_CHECK_WF( validated_reads_ch )
 

--- a/main.nf
+++ b/main.nf
@@ -13,7 +13,7 @@ include { MERGE_WF } from './workflows/merge_wf.nf'
 include { MINOR_VARIANTS_ANALYSIS_WF } from './workflows/minor_variants_analysis_wf.nf'
 include { QUALITY_CHECK_WF } from './workflows/quality_check_wf.nf'
 include { REPORTS_WF } from './workflows/reports_wf.nf'
-include { SAMPLESHEET_VALIDATION } from './modules/utils/samplesheet_validation.nf' 
+include { SAMPLESHEET_VALIDATION } from './modules/utils/samplesheet_validation.nf'  addParams ( params.SAMPLESHEET_VALIDATION )
 include { STRUCTURAL_VARIANTS_ANALYSIS_WF } from './workflows/structural_variants_analysis_wf.nf'
 include { UTILS_MERGE_COHORT_STATS } from "./modules/utils/merge_cohort_stats.nf" addParams ( params.UTILS_MERGE_COHORT_STATS )
 

--- a/main.nf
+++ b/main.nf
@@ -11,6 +11,7 @@ include { VALIDATE_FASTQS_WF } from './workflows/validate_fastqs_wf.nf'
 include { MAP_WF } from './workflows/map_wf.nf'
 include { MERGE_WF } from './workflows/merge_wf.nf'
 include { MINOR_VARIANTS_ANALYSIS_WF } from './workflows/minor_variants_analysis_wf.nf'
+//include { MULTIQC AS MULTIQC_FASTQS } from '../modules/multiqc/multiqc.nf' addParams (params.MULTIQC_FASTQS)
 include { QUALITY_CHECK_WF } from './workflows/quality_check_wf.nf'
 include { REPORTS_WF } from './workflows/reports_wf.nf'
 include { SAMPLESHEET_VALIDATION } from './modules/utils/samplesheet_validation.nf'  addParams ( params.SAMPLESHEET_VALIDATION )
@@ -30,6 +31,9 @@ workflow {
         validated_reads_ch = VALIDATE_FASTQS_WF( params.input_samplesheet , SAMPLESHEET_VALIDATION.out )
 
         QUALITY_CHECK_WF( validated_reads_ch )
+
+        //TODO: Add modules for generating fastq stats and then capturing them in the MultiQC image
+        //MULTIQC_FASTQS( QUALITY_CHECK_WF.out.reports_fastqc_ch )
 
     } else  {
 

--- a/modules/fastq_utils/validator.nf
+++ b/modules/fastq_utils/validator.nf
@@ -4,15 +4,11 @@ process FASTQ_VALIDATOR {
 
     stageInMode 'copy'
     maxRetries 3
-    //errorStrategy { task.exitStatus != 0 ? 'retry' : 'ignore' }
+    errorStrategy { task.exitStatus != 0 ? 'retry' : 'ignore' }
 
     //errorStrategy 'retry'
     //NOTE: Default action is to ignore the process if the second attempt fails
-    errorStrategy { (task.attempt < task.maxRetries) ? 'retry' : 'ignore' }
-
-
-
-
+    //errorStrategy { (task.attempt < task.maxRetries) ? 'retry' : 'ignore' }
 
     input:
         tuple val(sampleName), val(bamRgString), path(sampleReads)

--- a/modules/fastq_utils/validator.nf
+++ b/modules/fastq_utils/validator.nf
@@ -5,7 +5,7 @@ process FASTQ_VALIDATOR {
     stageInMode 'copy'
     maxRetries 3
     //errorStrategy { task.exitStatus != 0 ? 'retry' : 'ignore' }
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'ignore' }
+    errorStrategy { task.exitStatus == 1 ? 'retry' : 'ignore' }
 
 
     //errorStrategy 'retry'

--- a/modules/fastq_utils/validator.nf
+++ b/modules/fastq_utils/validator.nf
@@ -7,10 +7,6 @@ process FASTQ_VALIDATOR {
     errorStrategy { task.attempt < 3 ? 'retry' : 'ignore' }
 
 
-    //errorStrategy 'retry'
-    //NOTE: Default action is to ignore the process if the second attempt fails
-    //errorStrategy { (task.attempt < task.maxRetries) ? 'retry' : 'ignore' }
-
     input:
         tuple val(sampleName), val(bamRgString), path(sampleReads)
         val ready

--- a/modules/fastq_utils/validator.nf
+++ b/modules/fastq_utils/validator.nf
@@ -4,7 +4,9 @@ process FASTQ_VALIDATOR {
 
     stageInMode 'copy'
     maxRetries 3
-    errorStrategy { task.exitStatus != 0 ? 'retry' : 'ignore' }
+    //errorStrategy { task.exitStatus != 0 ? 'retry' : 'ignore' }
+    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'ignore' }
+
 
     //errorStrategy 'retry'
     //NOTE: Default action is to ignore the process if the second attempt fails

--- a/modules/fastq_utils/validator.nf
+++ b/modules/fastq_utils/validator.nf
@@ -4,7 +4,7 @@ process FASTQ_VALIDATOR {
 
     stageInMode 'copy'
     maxRetries 3
-    errorStrategy { task.exitStatus != 0 ? 'retry' : 'ignore' }
+    errorStrategy { task.attempts < 3 ? 'retry' : 'ignore' }
 
 
     //errorStrategy 'retry'

--- a/modules/fastq_utils/validator.nf
+++ b/modules/fastq_utils/validator.nf
@@ -2,8 +2,9 @@ process FASTQ_VALIDATOR {
     tag "${sampleName}"
     publishDir params.results_dir, mode: params.save_mode, enabled: params.should_publish
 
+    process.maxRetries 3
     //NOTE: Default action is to ignore the process if the second attempt fails
-    errorStrategy { (task.attempt <= 3) ? 'retry' : 'ignore' }
+    errorStrategy { (task.attempt <= process.maxRetries) ? 'retry' : 'ignore' }
     stageInMode 'copy'
 
 

--- a/modules/fastq_utils/validator.nf
+++ b/modules/fastq_utils/validator.nf
@@ -2,10 +2,12 @@ process FASTQ_VALIDATOR {
     tag "${sampleName}"
     publishDir params.results_dir, mode: params.save_mode, enabled: params.should_publish
 
-    maxRetries 3
-    //NOTE: Default action is to ignore the process if the second attempt fails
-    errorStrategy { (task.attempt <= process.maxRetries) ? 'retry' : 'ignore' }
     stageInMode 'copy'
+    maxRetries 3
+    errorStrategy 'retry'
+    //NOTE: Default action is to ignore the process if the second attempt fails
+    //errorStrategy { (task.attempt <= task.maxRetries) ? 'retry' : 'ignore' }
+
 
 
     input:

--- a/modules/fastq_utils/validator.nf
+++ b/modules/fastq_utils/validator.nf
@@ -3,7 +3,7 @@ process FASTQ_VALIDATOR {
     publishDir params.results_dir, mode: params.save_mode, enabled: params.should_publish
 
     //NOTE: Default action is to ignore the process if the second attempt fails
-    errorStrategy { task.attempt < 3 ? 'retry' : 'ignore' }
+    errorStrategy { (task.attempt <= 3) ? 'retry' : 'ignore' }
     stageInMode 'copy'
 
 

--- a/modules/fastq_utils/validator.nf
+++ b/modules/fastq_utils/validator.nf
@@ -4,9 +4,13 @@ process FASTQ_VALIDATOR {
 
     stageInMode 'copy'
     maxRetries 3
+    //errorStrategy { task.exitStatus != 0 ? 'retry' : 'ignore' }
+
     //errorStrategy 'retry'
     //NOTE: Default action is to ignore the process if the second attempt fails
     errorStrategy { (task.attempt <= task.maxRetries) ? 'retry' : 'ignore' }
+
+
 
 
 

--- a/modules/fastq_utils/validator.nf
+++ b/modules/fastq_utils/validator.nf
@@ -4,7 +4,7 @@ process FASTQ_VALIDATOR {
 
     stageInMode 'copy'
     maxRetries 3
-    errorStrategy { task.attempts < 3 ? 'retry' : 'ignore' }
+    errorStrategy { task.attempt < 3 ? 'retry' : 'ignore' }
 
 
     //errorStrategy 'retry'

--- a/modules/fastq_utils/validator.nf
+++ b/modules/fastq_utils/validator.nf
@@ -2,7 +2,7 @@ process FASTQ_VALIDATOR {
     tag "${sampleName}"
     publishDir params.results_dir, mode: params.save_mode, enabled: params.should_publish
 
-    process.maxRetries 3
+    maxRetries 3
     //NOTE: Default action is to ignore the process if the second attempt fails
     errorStrategy { (task.attempt <= process.maxRetries) ? 'retry' : 'ignore' }
     stageInMode 'copy'

--- a/modules/fastq_utils/validator.nf
+++ b/modules/fastq_utils/validator.nf
@@ -4,6 +4,7 @@ process FASTQ_VALIDATOR {
 
     //NOTE: Default action is to ignore the process if the second attempt fails
     errorStrategy { task.attempt < 3 ? 'retry' : 'ignore' }
+    stageInMode 'copy'
 
 
     input:

--- a/modules/fastq_utils/validator.nf
+++ b/modules/fastq_utils/validator.nf
@@ -4,8 +4,7 @@ process FASTQ_VALIDATOR {
 
     stageInMode 'copy'
     maxRetries 3
-    //errorStrategy { task.exitStatus != 0 ? 'retry' : 'ignore' }
-    errorStrategy { task.exitStatus == 1 ? 'retry' : 'ignore' }
+    errorStrategy { task.exitStatus != 0 ? 'retry' : 'ignore' }
 
 
     //errorStrategy 'retry'

--- a/modules/fastq_utils/validator.nf
+++ b/modules/fastq_utils/validator.nf
@@ -4,9 +4,9 @@ process FASTQ_VALIDATOR {
 
     stageInMode 'copy'
     maxRetries 3
-    errorStrategy 'retry'
+    //errorStrategy 'retry'
     //NOTE: Default action is to ignore the process if the second attempt fails
-    //errorStrategy { (task.attempt <= task.maxRetries) ? 'retry' : 'ignore' }
+    errorStrategy { (task.attempt <= task.maxRetries) ? 'retry' : 'ignore' }
 
 
 

--- a/modules/fastq_utils/validator.nf
+++ b/modules/fastq_utils/validator.nf
@@ -2,6 +2,10 @@ process FASTQ_VALIDATOR {
     tag "${sampleName}"
     publishDir params.results_dir, mode: params.save_mode, enabled: params.should_publish
 
+    //NOTE: Default action is to ignore the process if the second attempt fails
+    errorStrategy { task.attempt < 3 ? 'retry' : 'ignore' }
+
+
     input:
         tuple val(sampleName), val(bamRgString), path(sampleReads)
         val ready

--- a/modules/fastq_utils/validator.nf
+++ b/modules/fastq_utils/validator.nf
@@ -8,7 +8,7 @@ process FASTQ_VALIDATOR {
 
     //errorStrategy 'retry'
     //NOTE: Default action is to ignore the process if the second attempt fails
-    errorStrategy { (task.attempt <= task.maxRetries) ? 'retry' : 'ignore' }
+    errorStrategy { (task.attempt < task.maxRetries) ? 'retry' : 'ignore' }
 
 
 

--- a/modules/fastq_utils/validator.nf
+++ b/modules/fastq_utils/validator.nf
@@ -24,12 +24,15 @@ process FASTQ_VALIDATOR {
         if [ "$(echo "$TEMP")" == "OK" ]; then
             VALIDATED=1
             STATUS="passed"
+            echo -e "!{sampleName}\t${VALIDATED}" > !{sampleName}.check.${STATUS}.tsv
+            exit 0
         else
             VALIDATED=0
             STATUS="failed"
+            echo -e "!{sampleName}\t${VALIDATED}" > !{sampleName}.check.${STATUS}.tsv
+            exit 1
         fi
 
-        echo -e "!{sampleName}\t${VALIDATED}" > !{sampleName}.check.${STATUS}.tsv
 
         '''
 

--- a/modules/utils/samplesheet_validation.nf
+++ b/modules/utils/samplesheet_validation.nf
@@ -1,5 +1,7 @@
 process SAMPLESHEET_VALIDATION {
     publishDir params.results_dir, mode: params.save_mode, enabled: params.should_publish
+    //NOTE: If this process fails, terminate the pipeline execution
+    errorStrategy = 'terminate'
 
     input:
         path(samplesheet)

--- a/modules/utils/samplesheet_validation.nf
+++ b/modules/utils/samplesheet_validation.nf
@@ -7,7 +7,8 @@ process SAMPLESHEET_VALIDATION {
         path(samplesheet)
 
     output:
-        val true
+        val true, emit: status
+        path("samplesheet.valid.csv"), emit: validate_samplesheet
 
     script:
 

--- a/modules/utils/summarize_resistance_results.nf
+++ b/modules/utils/summarize_resistance_results.nf
@@ -1,5 +1,6 @@
 process UTILS_SUMMARIZE_RESISTANCE_RESULTS {
     publishDir params.results_dir, mode: params.save_mode, enabled: params.should_publish
+    stageInMode 'copy'
 
     input:
         path(merge_cohort_stats)

--- a/modules/utils/summarize_resistance_results_mixed_infection.nf
+++ b/modules/utils/summarize_resistance_results_mixed_infection.nf
@@ -1,5 +1,6 @@
 process UTILS_SUMMARIZE_RESISTANCE_RESULTS_MIXED_INFECTION {
     publishDir params.results_dir, mode: params.save_mode, enabled: params.should_publish
+    stageInMode 'copy'
 
     input:
         path(merge_cohort_stats)

--- a/nextflow.config
+++ b/nextflow.config
@@ -49,12 +49,6 @@ process {
         memory = 16.GB   
     }
  
-    
-    withName: 'SAMPLESHEET_VALIDATION' {
-        //NOTE: If this process fails, terminate the pipeline execution
-        errorStrategy = 'terminate'
-    }
-
 }
 
 


### PR DESCRIPTION
This PR does the following

1. Re-establish the dependency between SAMPLESHEET_VALIDATION and FAST_VALIDATION (and others) 

2. Improve the codebase of summarization scripts, simplication and publications of json data

3. Tighten the retry strategy for failing FASTQs

4. Publish the validated samplesheet to the results folder.

