### PR TITLE
update the default tree generation mechanism [ci skip]

### DIFF
--- a/default_params.config
+++ b/default_params.config
@@ -121,7 +121,7 @@ ref_fasta_rdanalyzer = "${projectDir}/resources/rdanalyzer/RDs30.fasta"
 
 
 //NOTE: PICK ONE of the following parameters related to IQTREE.
-iqtree_standard_bootstrap= false
+iqtree_standard_bootstrap= true
 iqtree_fast_ml_only= false
 iqtree_fast_bootstrapped_phylogeny= false
 iqtree_accurate_ml_only= false


### PR DESCRIPTION
The change is to have  `iqtree_standard_bootstrap: true` so that the final trees have the bootstrap values.