### PR TITLE
Add a Customizable IQ-TREE option

### DIFF
--- a/modules/iqtree/iqtree.nf
+++ b/modules/iqtree/iqtree.nf
@@ -55,6 +55,8 @@ process IQTREE {
             arguments = '-bb 1000 -alrt 1000'
         } else if(params.iqtree_accurate_ml_only) {
             arguments = '-allnni'
+        } else if(params.iqtree_custom_argument) {
+            arguments = params.iqtree_custom_argument
         } else {
         //NOTE: Use iqtree_accurate_ml_only as the default
             arguments = '-allnni'

--- a/modules/iqtree/iqtree.nf
+++ b/modules/iqtree/iqtree.nf
@@ -47,7 +47,9 @@ process IQTREE {
 
 
     script:
-        if(params.iqtree_standard_bootstrap) {
+        if(params.iqtree_custom_argument) {
+            arguments = params.iqtree_custom_argument
+        } else if(params.iqtree_standard_bootstrap) {
             arguments = '-b 1000'
         } else if(params.iqtree_fast_ml_only) {
             arguments = '-fast'
@@ -55,8 +57,6 @@ process IQTREE {
             arguments = '-bb 1000 -alrt 1000'
         } else if(params.iqtree_accurate_ml_only) {
             arguments = '-allnni'
-        } else if(params.iqtree_custom_argument) {
-            arguments = params.iqtree_custom_argument
         } else {
         //NOTE: Use iqtree_accurate_ml_only as the default
             arguments = '-allnni'

--- a/params/params.yaml
+++ b/params/params.yaml
@@ -63,3 +63,4 @@ iqtree_standard_bootstrap: false
 iqtree_fast_ml_only: false
 iqtree_fast_bootstrapped_phylogeny: false
 iqtree_accurate_ml_only: false
+iqtree_custom_argument: false


### PR DESCRIPTION
Hey 👋 @abhi18av,

After our last meeting, I'd like to kindly suggest the addition of a new parameter: `iqtree_custom_argument`, that would allow users to use specific bootstrap number or a specific phylogeny algoritm, as specified in IQ-TREE manual for advanced use of phylogeny inference, that would help to deal with big datasets.

The two basic changes on iqtree module and standard params would be enough to accommodate both of them, It worth to mention that the modifications cited on this PR have been tested with custom parameters using Evandro Chagas Institute infrastructure. 

## Example of how this parameter should be used:
```bash 

nextflow run main.nf -profile docker  --iqtree_standard_bootstrap false --iqtree_custom_argument "-bb 5000" --skip_phylogeny_and_clustering false

```

## Produced .command.sh:

```
 cat .command.sh
#!/bin/bash -ue
iqtree \
    -s joint.variable.ExDR.ExComplex.fa \
    -T AUTO \
    -bb 5000 \
    --prefix joint.ExDR.ExComplex
```
We could discuss if turning standard bootstrap off is a requirement to run custom params, or not, as this is a Complex feature intended for advanced users, I would like to suggest the strong enforcement of standard. Please, let me know your thoughts on that.


Kindly,
Davi

