### PR TITLE
Update params.yaml - Fix rel_abundance threshold

### DIFF
--- a/params/params.yaml
+++ b/params/params.yaml
@@ -18,7 +18,7 @@ cutoff_median_coverage : 10
 cutoff_breadth_of_coverage : 0.90
 
 #The relative abundunce of the majority strain required to process the sample
-cutoff_rel_abundance : 0.70
+cutoff_rel_abundance : 0.80
 
 #The maximum fraction of NTM DNA allowed to process the sample
 cutoff_ntm_fraction : 0.20


### PR DESCRIPTION
For some reason, the default relative abundance threshold was set at 0.70 here, but should be 0.80