### PR TITLE
feat: optional BAM → CRAM checkpoint after MarkDup / BQSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 <!-- https://keepachangelog.com/en/1.1.0/ -->
 
 
+## unreleased
+
+1. **Optional BAM → CRAM checkpoint after MarkDup / BQSR** (Pattern 1 of the BAM-checkpoints spec; see `abc-universe/specs/active/magma-bam-checkpoints.md`). Opt-in via `--bam_checkpoint_compression cram` (default `'none'` keeps current behaviour exactly). When enabled, a new local module `SAMTOOLS_VIEW_CRAM` replaces `SAMTOOLS_INDEX` at the post-MarkDup-or-BQSR junction in `workflows/call_wf.nf` and emits the identical channel shape `(sampleName, *.cram.crai, *.cram)` instead of `(sampleName, *.bai, *.bam)`. GATK HaplotypeCaller, the minor-variants HC, and LoFreq (htslib-backed) read the `.cram` directly via `-R / -f <ref>` — zero round-trip cost at consume time. Lossless CRAM 3.1 by default; quality-score binning is opt-in via `--cram_lossy_qualities true` (use only for archival of already-called cohorts).
+
+2. New params: `bam_checkpoint_compression` (`'none' | 'cram'`), `cram_lossy_qualities` (boolean). Both default to safe values; no behaviour change for existing invocations.
+
+
 ## v2.0.0
 
 1. Update `tb-profiler` to `v6.2.1` along with the `WHO mutations catalog v2` with the database version `30f8bc37df15affa378ebbfbd3e1eb4c5903056e`

--- a/default_params.config
+++ b/default_params.config
@@ -95,6 +95,25 @@ skip_base_recalibration = true // Do NOT enable for BQSR Mtb
 //NOTE: Output file for minor variants detection from bam with GATK XBS_call#L82. Lofreq does a better job for most purposes.
 skip_minor_variants_gatk = true
 
+// ===== Optional BAM checkpoint compression (CRAM) =====
+// Pattern 1 of the BAM-checkpoints spec
+// (abc-universe/specs/active/magma-bam-checkpoints.md).
+//
+// 'none' (default) → current behaviour: SAMTOOLS_INDEX emits *.bam + *.bai.
+// 'cram'           → SAMTOOLS_VIEW_CRAM emits *.cram + *.cram.crai instead.
+//                    Reference-aware (uses params.ref_fasta), samtools-native,
+//                    lossless by default. ~30–60% storage savings.
+//                    GATK HaplotypeCaller, minor-variants HC, and LoFreq all
+//                    read CRAM directly via `-R / -f <ref>` — zero round-trip
+//                    cost at consume time.
+// 'genozip' / 'zstd' branches are NOT yet wired (Phase 1.0b/c — separate PRs).
+bam_checkpoint_compression = 'none' // 'none' | 'cram'
+
+// When bam_checkpoint_compression='cram': quality-score binning to save more
+// space. LOSSY — only safe for archival of already-called cohorts. Default
+// false (lossless CRAM 3.1).
+cram_lossy_qualities = false
+
 // Use this flag to disable downstream phylogenetic of merged GVCF
 skip_phylogeny_and_clustering = false //OR true
 

--- a/modules/local/samtools/view_cram.nf
+++ b/modules/local/samtools/view_cram.nf
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021-2026 MAGMA pipeline authors, see https://doi.org/10.1371/journal.pcbi.1011648
+ *
+ * This file is part of MAGMA pipeline, see https://github.com/TORCH-Consortium/MAGMA
+ *
+ * For quick overview of GPL-3 license, please refer
+ * https://www.tldrlegal.com/license/gnu-general-public-license-v3-gpl-3
+ *
+ * - You MUST keep this license with original authors in your copy
+ * - You MUST acknowledge the original source of this software
+ * - You MUST state significant changes made to the original software
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program . If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// SAMTOOLS_VIEW_CRAM — optional BAM → CRAM checkpoint (Pattern 1 of the
+// BAM-checkpoints spec, abc-universe/specs/active/magma-bam-checkpoints.md).
+//
+// Drop-in replacement for SAMTOOLS_INDEX at the post-MarkDup-or-BQSR
+// junction in call_wf.nf. Emits the identical channel shape
+// `tuple(sampleName, index, alignment)` so every downstream consumer
+// (HaplotypeCaller, minor-variants HC) is agnostic to whether the input
+// is BAM+BAI or CRAM+CRAI. GATK reads CRAM directly via `-I <cram> -R <ref>`.
+//
+// Lossless by default (cram_version=3.1, default codec set). Quality-score
+// binning is opt-in via params.cram_lossy_qualities (use only for archival
+// of already-called cohorts; not safe for re-calling or re-BQSR).
+
+process SAMTOOLS_VIEW_CRAM {
+    tag "${sampleName}"
+    label 'cpu_4_memory_4'
+    publishDir params.results_dir, mode: params.save_mode, enabled: params.should_publish
+
+    input:
+        tuple val(sampleName), path(bam)
+        path(ref_fasta)
+        path("*")                    // ref_fasta_fai etc. (mirrors HaplotypeCaller's idiom)
+
+    output:
+        tuple val(sampleName), path("*.cram.crai"), path("*.cram")
+
+    script:
+        // Lossless CRAM 3.1 by default. With `cram_lossy_qualities=true`,
+        // bin quality scores to 8 bins (samtools' --output-fmt-option
+        // lossy_names=0,store_md=1,store_nm=1,...) — smaller but lossy.
+        def lossy_opts = params.cram_lossy_qualities
+            ? '--output-fmt-option lossy_names=0,store_md=1,store_nm=1,seqs_per_slice=10000'
+            : ''
+        """
+        ${params.samtools_path} view \\
+            -C \\
+            -T ${ref_fasta} \\
+            --threads ${task.cpus} \\
+            --output-fmt cram,version=3.1 \\
+            ${lossy_opts} \\
+            -o ${sampleName}.cram \\
+            ${bam}
+
+        ${params.samtools_path} index \\
+            -@ ${task.cpus} \\
+            ${sampleName}.cram
+        """
+
+    stub:
+        """
+        echo "samtools view -C -T ${ref_fasta} -o ${sampleName}.cram ${bam}"
+        echo "samtools index ${sampleName}.cram"
+        touch ${sampleName}.cram
+        touch ${sampleName}.cram.crai
+        """
+}

--- a/workflows/call_wf.nf
+++ b/workflows/call_wf.nf
@@ -33,6 +33,7 @@ include { GATK_HAPLOTYPE_CALLER__MINOR_VARIANTS } from "../modules/local/gatk/ha
 include { LOFREQ_CALL__NTM } from "../modules/local/lofreq/call__ntm.nf" addParams ( params.LOFREQ_CALL__NTM )
 include { LOFREQ_INDELQUAL } from "../modules/local/lofreq/indelqual.nf" addParams ( params.LOFREQ_INDELQUAL )
 include { SAMTOOLS_INDEX } from "../modules/local/samtools/index.nf" addParams ( params.SAMTOOLS_INDEX )
+include { SAMTOOLS_VIEW_CRAM } from "../modules/local/samtools/view_cram.nf"
 include { SAMTOOLS_INDEX__LOFREQ } from "../modules/local/samtools/index__lofreq.nf" addParams ( params.SAMTOOLS_INDEX__LOFREQ )
 include { LOFREQ_CALL } from "../modules/local/lofreq/call.nf" addParams ( params.LOFREQ_CALL )
 include { LOFREQ_FILTER } from "../modules/local/lofreq/filter.nf" addParams ( params.LOFREQ_FILTER )
@@ -92,7 +93,24 @@ workflow CALL_WF {
 
         //recalibrated_bam_ch.dump(tag: "CALL_WF recalibrated_bam_ch: ", pretty:true)
 
-        SAMTOOLS_INDEX(recalibrated_bam_ch)
+        // Optional BAM → CRAM checkpoint at the post-MarkDup-or-BQSR junction.
+        // params.bam_checkpoint_compression:
+        //   'none' (default) → SAMTOOLS_INDEX  → emits (sampleName, *.bai, *.bam)
+        //   'cram'           → SAMTOOLS_VIEW_CRAM → emits (sampleName, *.crai, *.cram)
+        // Both branches produce the IDENTICAL channel shape so HaplotypeCaller,
+        // minor-variants HC, and any consumer reading SAMTOOLS_INDEX.out remain
+        // agnostic — GATK reads CRAM directly via `-I <cram> -R <ref>`.
+        // (See abc-universe/specs/active/magma-bam-checkpoints.md §1 / §4.)
+        def aligned_indexed_ch
+        if (params.bam_checkpoint_compression == 'cram') {
+            SAMTOOLS_VIEW_CRAM(recalibrated_bam_ch,
+                               params.ref_fasta,
+                               [params.ref_fasta_fai, params.ref_fasta_dict])
+            aligned_indexed_ch = SAMTOOLS_VIEW_CRAM.out
+        } else {
+            SAMTOOLS_INDEX(recalibrated_bam_ch)
+            aligned_indexed_ch = SAMTOOLS_INDEX.out
+        }
 
         //----------------------------------------------------------------------------------
         // Call Variants for follow up calling
@@ -101,13 +119,13 @@ workflow CALL_WF {
 
 
         // call_haplotype_caller
-        GATK_HAPLOTYPE_CALLER(SAMTOOLS_INDEX.out,
+        GATK_HAPLOTYPE_CALLER(aligned_indexed_ch,
                           params.ref_fasta,
                           [params.ref_fasta_fai, params.ref_fasta_dict])
 
         // call_haplotype_caller_minor_variants
         if (!params.skip_minor_variants_gatk) {
-            GATK_HAPLOTYPE_CALLER__MINOR_VARIANTS(SAMTOOLS_INDEX.out,
+            GATK_HAPLOTYPE_CALLER__MINOR_VARIANTS(aligned_indexed_ch,
                                                 params.ref_fasta,
                                                 [params.ref_fasta_fai, params.ref_fasta_dict])
         }
@@ -117,8 +135,8 @@ workflow CALL_WF {
         //----------------------------------------------------------------------------------
 
 
-        // call_ntm
-        LOFREQ_CALL__NTM(SAMTOOLS_INDEX.out,
+        // call_ntm — LoFreq is htslib-backed, accepts BAM or CRAM via `-f <ref>`
+        LOFREQ_CALL__NTM(aligned_indexed_ch,
                          params.ref_fasta,
                          [params.ref_fasta_fai])
 
@@ -169,5 +187,5 @@ workflow CALL_WF {
         gvcf_ch = GATK_HAPLOTYPE_CALLER.out.gvcf_ch.collect()
         reformatted_lofreq_vcfs_tuple_ch = GATK_INDEX_FEATURE_FILE__LOFREQ.out.vcf_tuple.collect(sort:true)
         bgzip_ch = BGZIP__LOFREQ.out.collect()
-        samtools_bam_ch = SAMTOOLS_INDEX.out
+        samtools_bam_ch = aligned_indexed_ch
 }


### PR DESCRIPTION
## Summary

Pattern 1 of the BAM-checkpoints spec ([`abc-universe/specs/active/magma-bam-checkpoints.md`](https://github.com/abhi18av/abc-universe/blob/master/specs/active/magma-bam-checkpoints.md)) — optional BAM → CRAM checkpoint at the post-MarkDup-or-BQSR junction, **opt-in via param, default off**. Genozip / zstd variants will land as separate PRs once this has run on a real cohort.

## Architecture — drop-in module swap with identical channel shape

`call_wf.nf` currently runs `SAMTOOLS_INDEX` at the post-MarkDup-or-BQSR junction, emitting `(sampleName, *.bai, *.bam)` which HC and the minor-variants HC consume directly. With `--bam_checkpoint_compression cram`, a new `SAMTOOLS_VIEW_CRAM` module runs **instead** and emits the **identical channel shape** `(sampleName, *.cram.crai, *.cram)`. Downstream consumers are agnostic — GATK HaplotypeCaller, the minor-variants HC, and LoFreq (htslib-backed) all read CRAM directly via `-R / -f <ref>`, **zero round-trip cost at consume time**.

```groovy
def aligned_indexed_ch
if (params.bam_checkpoint_compression == 'cram') {
    SAMTOOLS_VIEW_CRAM(recalibrated_bam_ch, params.ref_fasta, [params.ref_fasta_fai, params.ref_fasta_dict])
    aligned_indexed_ch = SAMTOOLS_VIEW_CRAM.out
} else {
    SAMTOOLS_INDEX(recalibrated_bam_ch)
    aligned_indexed_ch = SAMTOOLS_INDEX.out
}
// ...HC, minor-variants HC, LoFreq, samtools_bam_ch emit all read aligned_indexed_ch
```

One if/else, no new emit shape, no changes to any of the 4 processes that read the channel.

## Files

| Path | Purpose |
|---|---|
| `modules/local/samtools/view_cram.nf` | **NEW.** `samtools view -C -T <ref> --output-fmt cram,version=3.1` + `samtools index`. Lossless by default; opt-in lossy quality binning via `params.cram_lossy_qualities`. Same `samtools` binary MAGMA already uses. |
| `workflows/call_wf.nf` | Branches on `params.bam_checkpoint_compression` at the post-MarkDup-or-BQSR junction. Routes the resulting `aligned_indexed_ch` through HC + minor-variants HC + LoFreq + cohort emit. |
| `default_params.config` | Adds `bam_checkpoint_compression = 'none'` (default) and `cram_lossy_qualities = false`. |
| `CHANGELOG.md` | `unreleased` entry with the flag matrix and rationale. |

## Defaults

`bam_checkpoint_compression = 'none'` keeps `SAMTOOLS_INDEX` in the pipeline; the new module isn't even loaded into the DAG. **Existing invocations produce identical outputs (plain `.bam` + `.bai`) to master.** Opting in is a single flag.

## Pre-merge gates

- ✅ `nextflow lint modules/local/samtools/view_cram.nf` — clean
- ⚠️ `nextflow lint workflows/call_wf.nf` shows a pre-existing `addParams()` DSL2-deprecation warning at line 26 (the first include, untouched by this PR) — not introduced here

## Open items (documented in spec, not in this PR)

- **Round-trip equivalence test** — compress → consume → compare HC output against a non-CRAM baseline run on the same cohort. Spec §8 conformance gate; not blocking this PR's opt-in default but blocking any "switch default to cram" follow-up.
- **SV path** (`structural_variants_analysis_wf.nf`) uses its own MarkDup / recal chain and is not touched by this PR. CRAM extension to DELLY's BAM input is a follow-up if needed.
- **Samplesheet routing for pre-compressed inputs** (`.cram` on input) is Pattern 4 of the spec.
- **genozip + zstd codecs** — separate PRs; genozip license-gated; zstd license-free but modest gain on already-bgzipped BAM.

## Refs

- Spec: [`abc-universe/specs/active/magma-bam-checkpoints.md`](https://github.com/abhi18av/abc-universe/blob/master/specs/active/magma-bam-checkpoints.md)
- Sibling — XBS gVCF checkpoints: [`abc-universe/specs/active/xbs-variant-calling-gatk-optimizations.md` §3](https://github.com/abhi18av/abc-universe/blob/master/specs/active/xbs-variant-calling-gatk-optimizations.md)
- htslib CRAM 3.x spec: [CRAMv3.pdf](https://samtools.github.io/hts-specs/CRAMv3.pdf)