### PR TITLE
Fix conda setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ conda env list
 
 8. Use the prior command result to update the "conda_envs_location" parameter with a suitable path
 
-> :warning::warning::warning: **If you used the setup conda envs script, this step is unecessary**
+> :warning::warning::warning: **If you used the setup conda envs script, this step is unnecessary**
 
 ## Running MAGMA using docker
 

--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ You can use the `conda` based setup for the pipeline for running MAGMA
 All the requisite softwares have been provided as a `conda` recipe (i.e. `yml` files)
 - [magma-env-1.yml](./conda_envs/magma-env-1.yml)
 - [magma-env-2.yml](./conda_envs/magma-env-2.yml)
-- [magma-ntmprofiler-env.yaml](./conda_envs/magma-ntmprofiler-env.yaml)
-- [magma-tbprofiler-env.yaml](./conda_envs/magma-tbprofiler-env.yaml)
+- [magma-ntmprofiler-env.yml](./conda_envs/magma-ntmprofiler-env.yml)
+- [magma-tbprofiler-env.yml](./conda_envs/magma-tbprofiler-env.yml)
 
 These files can be downloaded using the following commands
 

--- a/README.md
+++ b/README.md
@@ -201,13 +201,16 @@ You can use the `conda` based setup for the pipeline for running MAGMA
 All the requisite softwares have been provided as a `conda` recipe (i.e. `yml` files)
 - [magma-env-1.yml](./conda_envs/magma-env-1.yml)
 - [magma-env-2.yml](./conda_envs/magma-env-2.yml)
+- [magma-ntmprofiler-env.yaml](./conda_envs/magma-ntmprofiler-env.yaml)
+- [magma-tbprofiler-env.yaml](./conda_envs/magma-tbprofiler-env.yaml)
 
 These files can be downloaded using the following commands
 
 ```console
 wget https://raw.githubusercontent.com/TORCH-Consortium/MAGMA/master/conda_envs/magma-env-2.yml
 wget https://raw.githubusercontent.com/TORCH-Consortium/MAGMA/master/conda_envs/magma-env-1.yml
-
+wget https://raw.githubusercontent.com/TORCH-Consortium/MAGMA/master/conda_envs/magma-ntmprofiler-env.yaml
+wget https://raw.githubusercontent.com/TORCH-Consortium/MAGMA/master/conda_envs/magma-tbprofiler-env.yaml
 ```
 
 The `conda` environments are expected by the `conda_local` profile of the pipeline, it is recommended that it should be created **prior** to the use of the pipeline, using the following commands. Note that if you have `mamba` (or `micromamba`) available you can rely upon that instead of `conda`.
@@ -225,37 +228,45 @@ Once the environments are created, you can make use of the pipeline parameter `c
 
 Next, you need to load the WHO Resistance Catalog within `tb-profiler`; basically the [instructions](https://github.com/TORCH-Consortium/MAGMA/blob/master/conda_envs/setup_conda_envs.sh#L20-L23), which are used to build the necessary containers.
 
-1. Download [magma_resistance_db_who_v1.zip](https://github.com/TORCH-Consortium/MAGMA/files/14559680/resistance_db_who_v1.zip)  and unzip it
+
+1. Activate `magma-tbprofiler-env`, which has `tb-profiler`
 
 ```console
-wget https://github.com/TORCH-Consortium/MAGMA/files/14559680/resistance_db_who_v1.zip
-
-unzip resistance_db_who
-
+conda activate magma-tbprofiler-env
 ```
 
-2. Activate `magma-env-1`, which has `tb-profiler`
+2. Use tbprofiler updatedb command to download the correct database
 
 ```console
-conda activate magma-env-1
-
+tb-profiler update_tbdb --commit 30f8bc37df15affa378ebbfbd3e1eb4c5903056e --logging DEBUG
 ```
 
-3. Move inside that folder and use `tb-profiler load_library` functionality to load the database
+3. Now you can deactivate the environment and setup the next one
+```console
+conda deactivate
+```
+4. Activate `magma-ntmprofiler-env`, which has `ntm-profiler`
+```console
+conda activate magma-ntmprofiler-env
+```
+5. Use NTM profiler to download the built-in database
+```console
+ntm-profiler update_db --logging DEBUG
+```
+6. Now you can deactivate the environment
+```console
+conda deactivate
+```
 
+7. Prior to running MAGMA you should locate the conda environments created
 
 ```console
-
-cd resistance_db_who
-
-tb-profiler load_library ./resistance_db_who
-
+conda env list
 ```
 
-Success, would look like this
-<img width="1060" alt="image" src="https://github.com/TORCH-Consortium/MAGMA/assets/12799326/de5eb0fc-c636-44f6-a787-39bbbf8bc8c7">
+8. Use the prior command result to update the "conda_envs_location" parameter with a suitable path
 
-
+> :warning::warning::warning: **If you used the setup conda envs script, this step is unecessary**
 
 ## Running MAGMA using docker
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Next, you need to load the WHO Resistance Catalog within `tb-profiler`; basicall
 conda activate magma-tbprofiler-env
 ```
 
-2. Use tbprofiler updatedb command to download the correct database
+2. Use `tb-profiler update_tbdb` to download the correct database
 
 ```console
 tb-profiler update_tbdb --commit 30f8bc37df15affa378ebbfbd3e1eb4c5903056e --logging DEBUG

--- a/README.md
+++ b/README.md
@@ -209,8 +209,8 @@ These files can be downloaded using the following commands
 ```console
 wget https://raw.githubusercontent.com/TORCH-Consortium/MAGMA/master/conda_envs/magma-env-2.yml
 wget https://raw.githubusercontent.com/TORCH-Consortium/MAGMA/master/conda_envs/magma-env-1.yml
-wget https://raw.githubusercontent.com/TORCH-Consortium/MAGMA/master/conda_envs/magma-ntmprofiler-env.yaml
-wget https://raw.githubusercontent.com/TORCH-Consortium/MAGMA/master/conda_envs/magma-tbprofiler-env.yaml
+wget https://raw.githubusercontent.com/TORCH-Consortium/MAGMA/master/conda_envs/magma-ntmprofiler-env.yml
+wget https://raw.githubusercontent.com/TORCH-Consortium/MAGMA/master/conda_envs/magma-tbprofiler-env.yml
 ```
 
 The `conda` environments are expected by the `conda_local` profile of the pipeline, it is recommended that it should be created **prior** to the use of the pipeline, using the following commands. Note that if you have `mamba` (or `micromamba`) available you can rely upon that instead of `conda`.

--- a/conda_envs/setup_conda_envs.sh
+++ b/conda_envs/setup_conda_envs.sh
@@ -14,10 +14,6 @@ $resolverCondaBinary env create -p magma-env-1 --file magma-env-1.yml
 
 $resolverCondaBinary env create -p magma-env-2 --file magma-env-2.yml 
 
-$resolverCondaBinary env create -p magma-ntmprofiler-env --file magma-ntmprofiler-env.yml
-
-$resolverCondaBinary env create -p magma-tbprofiler-env --file magma-tbprofiler-env.yml
-
 #===========================================================
 
 #NOTE: Setup the tbprofiler env with WHO v2 Database
@@ -36,4 +32,18 @@ tb-profiler update_tbdb --commit 30f8bc37df15affa378ebbfbd3e1eb4c5903056e --logg
 
 
 echo "INFO: Deactivate the magma-tbprofiler-env "
+conda deactivate
+
+#NOTE: Setup the ntmprofiler env with ntm database
+
+$resolverCondaBinary env create -p magma-ntmprofiler-env --file magma-ntmprofiler-env.yml
+
+echo "INFO: Activate conda env with ntm-profiler and setup the ntm database"
+eval "$(conda shell.bash hook)"
+conda activate "./magma-ntmprofiler-env"
+
+# Use NTM profiler to download the built-in database
+ntm-profiler update_db
+
+echo "INFO: Deactivate the magma-ntmprofiler-env "
 conda deactivate

--- a/conda_envs/setup_conda_envs.sh
+++ b/conda_envs/setup_conda_envs.sh
@@ -43,7 +43,7 @@ eval "$(conda shell.bash hook)"
 conda activate "./magma-ntmprofiler-env"
 
 # Use NTM profiler to download the built-in database
-ntm-profiler update_db
+ntm-profiler update_db --logging DEBUG
 
 echo "INFO: Deactivate the magma-ntmprofiler-env "
 conda deactivate


### PR DESCRIPTION
Dear Abhinav,

Yesterday, I met with @justicengom to help him set up the MAGMA Conda environment. During the installation process, I noticed a couple of issues with the documentation and the Conda setup instructions:

1. The main README does not include instructions for creating the **TB-Profiler** and **NTM-Profiler** Conda environments.
2. The `setup_conda_envs.sh` script does not download the NTM database required by NTM-Profiler.

These issues can be reproduced by following the installation steps described in the README from a clean environment.

To help keep MAGMA up to date with the latest changes and ensure the installation process remains straightforward for new users, I would like to suggest a few updates to both the documentation and the `setup_conda_envs.sh` script.

I'm happy to discuss these suggestions further and help implement any necessary modifications.

Thank you for your time and consideration.

Kind regards,

Davi
